### PR TITLE
SYN-RBL: gate balanced=True on confidence > 0.8

### DIFF
--- a/scripts/run_syn_rbl_full.py
+++ b/scripts/run_syn_rbl_full.py
@@ -25,6 +25,12 @@ import polars as pl
 
 from aichemy.preprocessing.balance.syn_rbl import balance_reactions
 
+# Trust deterministic SYN-RBL solves (rule-based / input-balanced report no
+# confidence); require confidence > 0.8 for MCS-imputed solves where SYN-RBL
+# is guessing missing compounds and can produce nonsense (e.g. CCCC.O>>CCCO
+# "fixed" to CCCC.O.[O]>>CCCO.CO at confidence 0.30).
+CONFIDENCE_THRESHOLD = 0.8
+
 
 def main() -> int:
     parser = argparse.ArgumentParser()
@@ -80,14 +86,19 @@ def main() -> int:
         rxn_smiles_list = chunk["reaction_smiles"].to_list()
 
         t0 = time.time()
-        balanced_smiles = balance_reactions(rxn_smiles_list, n_jobs=args.workers)
+        balance_results = balance_reactions(rxn_smiles_list, n_jobs=args.workers)
         elapsed = time.time() - t0
 
         # Attach results back to the chunk.
-        balanced_bool = [b is not None for b in balanced_smiles]
+        balanced_bool = [
+            smi is not None and (conf is None or conf > CONFIDENCE_THRESHOLD)
+            for smi, conf in balance_results
+        ]
         new_rxn_smiles = [
-            balanced if balanced is not None else orig
-            for orig, balanced in zip(rxn_smiles_list, balanced_smiles, strict=True)
+            smi if is_bal else orig
+            for orig, (smi, _conf), is_bal in zip(
+                rxn_smiles_list, balance_results, balanced_bool, strict=True
+            )
         ]
         out_df = chunk.with_columns(
             pl.Series("reaction_smiles", new_rxn_smiles),

--- a/src/aichemy/preprocessing/balance/syn_rbl.py
+++ b/src/aichemy/preprocessing/balance/syn_rbl.py
@@ -75,13 +75,24 @@ def _normalize_for_synrbl(rxn: str) -> str | None:
 def balance_reactions(
     reaction_smiles: Iterable[str],
     n_jobs: int = 1,
-) -> list[str | None]:
-    """Run SYN-RBL over a list of reaction SMILES; return balanced strings.
+) -> list[tuple[str | None, float | None]]:
+    """Run SYN-RBL over a list of reaction SMILES; return (smiles, confidence).
 
-    Returns None for entries that SYN-RBL could not process or balance.
-    On a whole-batch crash, returns all None — caller should pick a chunk
-    size that makes that loss acceptable (e.g. 1000 means losing 0.05% on
-    a 1.8M corpus if one chunk crashes).
+    Per-input return semantics:
+      * ``(None, None)``         — SYN-RBL produced no usable output for this
+                                   input (filtered as malformed, dropped by
+                                   SYN-RBL, or whole-batch crash).
+      * ``(smiles, None)``       — solved by a deterministic path
+                                   (``rule-based`` / ``input-balanced``);
+                                   SYN-RBL does not report a confidence score
+                                   for these — they're rule-driven bookkeeping.
+      * ``(smiles, float)``      — solved by ``mcs-based`` imputation; the
+                                   float is SYN-RBL's confidence in [0, 1].
+                                   Callers should apply their own threshold.
+
+    On a whole-batch crash, returns all ``(None, None)`` — caller should
+    pick a chunk size that makes that loss acceptable (e.g. 1000 means
+    losing 0.05% on a 1.8M corpus if one chunk crashes).
     """
     Balancer = _import_balancer()
     bal = Balancer(n_jobs=n_jobs)
@@ -92,13 +103,13 @@ def balance_reactions(
     normalized: list[str | None] = [_normalize_for_synrbl(r) for r in rxns]
     valid_pairs = [(i, r) for i, r in enumerate(normalized) if r is not None]
 
-    out: list[str | None] = [None] * len(rxns)
+    out: list[tuple[str | None, float | None]] = [(None, None)] * len(rxns)
     if not valid_pairs:
         return out
 
     try:
         with _suppress_synrbl_noise():
-            results = bal.rebalance([r for _, r in valid_pairs])
+            results = bal.rebalance([r for _, r in valid_pairs], output_dict=True)
     except Exception as exc:
         log.warning(
             "SYN-RBL batch of %d crashed (%s); chunk lost.",
@@ -107,21 +118,13 @@ def balance_reactions(
         )
         return out
 
-    # SYN-RBL sometimes returns a list[str], sometimes a DataFrame. Normalize.
-    if hasattr(results, "to_dict"):
-        # Pandas DataFrame — prefer the reactions column, fall back to first col.
-        cols = list(results.columns) if hasattr(results, "columns") else []
-        if "reactions" in cols:
-            results = results["reactions"].tolist()
-        elif "reaction_smiles" in cols:
-            results = results["reaction_smiles"].tolist()
-        elif cols:
-            results = results[cols[0]].tolist()
-        else:
-            results = []
-
     for (i, _), result in zip(valid_pairs, results, strict=False):
-        if isinstance(result, str) and result:
-            out[i] = result
+        if not isinstance(result, dict) or not result.get("solved"):
+            continue
+        reaction = result.get("reaction")
+        if not isinstance(reaction, str) or not reaction:
+            continue
+        confidence = result.get("confidence")
+        out[i] = (reaction, float(confidence) if confidence is not None else None)
 
     return out

--- a/tests/unit/test_balance_syn_rbl.py
+++ b/tests/unit/test_balance_syn_rbl.py
@@ -26,7 +26,10 @@ def test_balance_reactions_fixes_missing_water() -> None:
     # needs water on the reactant side to balance.
     result = balance_reactions(["CC(=O)OCC>>CC(=O)O.CCO"], n_jobs=1)
     assert len(result) == 1
+    smi, conf = result[0]
     # SYN-RBL should add the missing water; the exact SMILES varies but
-    # "O" (water) should appear.
-    assert result[0] is not None
-    assert "O" in result[0]
+    # "O" (water) should appear. Ester hydrolysis solves on the rule-based
+    # path, which reports no confidence.
+    assert smi is not None
+    assert "O" in smi
+    assert conf is None

--- a/tests/unit/test_balance_syn_rbl.py
+++ b/tests/unit/test_balance_syn_rbl.py
@@ -17,6 +17,15 @@ def test_balance_reactions_empty_input_returns_empty() -> None:
     assert balance_reactions([]) == []
 
 
+def test_balance_reactions_malformed_input_returns_none_pair() -> None:
+    from aichemy.preprocessing.balance.syn_rbl import balance_reactions
+
+    # _normalize_for_synrbl filters these before SYN-RBL is called, so
+    # synrbl need not be installed for this test to pass.
+    result = balance_reactions(["not_a_smiles", "", "no_arrow_here"], n_jobs=1)
+    assert result == [(None, None), (None, None), (None, None)]
+
+
 @pytest.mark.slow
 def test_balance_reactions_fixes_missing_water() -> None:
     pytest.importorskip("synrbl")


### PR DESCRIPTION
## Summary

SYN-RBL has two solve paths:
- **Deterministic** (`rule-based` / `input-balanced`): rule-driven bookkeeping; no `confidence` reported.
- **Inferential** (`mcs-based`): imputes missing compounds via maximum-common-substructure search. Returns a `confidence` float in [0, 1] and can produce nonsense — e.g. `CCCC.O>>CCCO` came back "fixed" as `CCCC.O.[O]>>CCCO.CO` at confidence 0.30.

Previously every `solved=True` row was marked `balanced=True` in the shard parquet, so noisy MCS imputations polluted the balanced output. This PR adds a confidence gate.

Effective gate: `solved AND (confidence is None OR confidence > 0.8)`.

## Changes

- `src/aichemy/preprocessing/balance/syn_rbl.py`: `balance_reactions` now returns `list[tuple[str | None, float | None]]` and calls `bal.rebalance(..., output_dict=True)` so it can surface SYN-RBL's confidence. `(None, None)` for failures, `(smi, None)` for deterministic solves, `(smi, float)` for MCS solves. Drops the DataFrame fallback that's no longer reachable.
- `scripts/run_syn_rbl_full.py`: applies `CONFIDENCE_THRESHOLD = 0.8`. `balanced=True` only when SMILES is non-None AND (conf is None OR conf > 0.8). When the gate fails, the original `reaction_smiles` is preserved.
- `tests/unit/test_balance_syn_rbl.py`: updated for the tuple return; asserts ester-hydrolysis comes back via the rule-based path with `conf is None`.

## Test plan

- [x] `uv run ruff check` on the three changed files
- [x] `uv run mypy src/aichemy/preprocessing/balance/syn_rbl.py scripts/run_syn_rbl_full.py`
- [x] `uv run pytest tests/unit/test_balance_syn_rbl.py -v` (fast + slow paths)
- [x] End-to-end smoke: rule-based hydrolysis stays balanced (conf=None), bogus MCS imputation `CCCC.O>>CCCO` now has `balanced=False` (conf=0.30 ≤ 0.8), garbage input → `(None, None)`.
- [ ] Re-run `scripts/run_syn_rbl_full.py` on the full USPTO corpus to regenerate shard parquets (out of scope for this PR).

## Out of scope

- Threshold tuning beyond 0.8.
- Pre-existing positional-alignment fragility between SYN-RBL output and `valid_pairs`.
- Deleting/regenerating existing shard parquets.

https://claude.ai/code/session_013pGq7LffrkQU3zvL52ReQ7

---
_Generated by [Claude Code](https://claude.ai/code/session_013pGq7LffrkQU3zvL52ReQ7)_