### PR TITLE
Fix CI: ruff F841 + mypy errors blocking main

### DIFF
--- a/scripts/estimate_prices_zinc_style.py
+++ b/scripts/estimate_prices_zinc_style.py
@@ -47,15 +47,11 @@ def _estimate_price_per_gram(smiles: str) -> float | None:
     if heavy_atoms == 0:
         return None
 
-    # Count atom types
-    n_c = sum(1 for a in mol.GetAtoms() if a.GetSymbol() == "C")
+    # Count atom types referenced by the price formula below.
     n_n = sum(1 for a in mol.GetAtoms() if a.GetSymbol() == "N")
-    n_o = sum(1 for a in mol.GetAtoms() if a.GetSymbol() == "O")
     n_s = sum(1 for a in mol.GetAtoms() if a.GetSymbol() == "S")
     n_p = sum(1 for a in mol.GetAtoms() if a.GetSymbol() == "P")
-    n_halogen = sum(
-        1 for a in mol.GetAtoms() if a.GetSymbol() in ("F", "Cl", "Br", "I")
-    )
+    n_halogen = sum(1 for a in mol.GetAtoms() if a.GetSymbol() in ("F", "Cl", "Br", "I"))
     n_aromatic = sum(1 for a in mol.GetAtoms() if a.GetIsAromatic())
     n_rings = mol.GetRingInfo().NumRings()
 
@@ -100,10 +96,7 @@ def main() -> int:
     parser.add_argument(
         "--molecules-path",
         type=Path,
-        default=Path(__file__).resolve().parents[1]
-        / "data"
-        / "processed"
-        / "molecules.parquet",
+        default=Path(__file__).resolve().parents[1] / "data" / "processed" / "molecules.parquet",
     )
     args = parser.parse_args()
 

--- a/src/aichemy/scrapers/prices/askcos.py
+++ b/src/aichemy/scrapers/prices/askcos.py
@@ -89,7 +89,7 @@ class AskcosCatalog:
             raw = json.load(f)
         log.info("AskcosCatalog: canonicalizing %d SMILES (cold path)...", len(raw))
 
-        RDLogger.DisableLog("rdApp.*")
+        RDLogger.DisableLog("rdApp.*")  # type: ignore[attr-defined]
         try:
             for row in raw:
                 smi = row.get("smiles")
@@ -110,7 +110,7 @@ class AskcosCatalog:
                         raw_smiles=smi,
                     )
         finally:
-            RDLogger.EnableLog("rdApp.*")
+            RDLogger.EnableLog("rdApp.*")  # type: ignore[attr-defined]
 
         log.info(
             "AskcosCatalog: loaded %d unique canonical SMILES from %d raw rows",

--- a/src/aichemy/scrapers/prices/pubchem.py
+++ b/src/aichemy/scrapers/prices/pubchem.py
@@ -15,6 +15,7 @@ import json
 import logging
 import time
 from dataclasses import dataclass
+from typing import Any
 from urllib.parse import quote
 
 import httpx
@@ -51,7 +52,7 @@ class PubChemResolver:
             time.sleep(self._rate - elapsed)
         self._last_call = time.monotonic()
 
-    def _get(self, path: str) -> dict | None:
+    def _get(self, path: str) -> dict[str, Any] | None:
         self._throttle()
         url = f"{BASE}/{path}"
         try:
@@ -62,7 +63,8 @@ class PubChemResolver:
         if resp.status_code != 200:
             return None
         try:
-            return resp.json()
+            data: dict[str, Any] = resp.json()
+            return data
         except json.JSONDecodeError:
             return None
 


### PR DESCRIPTION
## Summary

CI on `main` has been red because of pre-existing lint and typecheck errors unrelated to recent feature work. PR #3 (the SYN-RBL confidence-threshold fix) inherited the same red CI. This PR fixes everything blocking green CI.

### Lint (ruff F841)
- `scripts/estimate_prices_zinc_style.py:51,53` — `n_c` (carbon count) and `n_o` (oxygen count) are computed in `_estimate_price_per_gram` but the price formula below only uses `n_n`, `n_s`, `n_p`, `n_halogen`, `n_aromatic`, `n_rings`. Drop the two dead lines.
- Pre-commit's `ruff-format` hook also incidentally modernized `datetime.now(timezone.utc)` → `datetime.now(UTC)` (Python 3.11+) and collapsed the `n_halogen` `sum()` onto one line. Pure formatter changes, no behavior delta.

### Typecheck (mypy)
- `src/aichemy/scrapers/prices/askcos.py:92,113` — `RDLogger.{Disable,Enable}Log` work at runtime but RDKit's Python stubs don't expose them. Add `# type: ignore[attr-defined]` on the two call sites. (Same pattern works in `syn_rbl.py` because mypy's stale-cache behavior only flagged the askcos imports — adding the comments keeps it honest.)
- `src/aichemy/scrapers/prices/pubchem.py:54` — `dict | None` is missing type args; tighten to `dict[str, Any] | None`.
- `src/aichemy/scrapers/prices/pubchem.py:65` — `httpx.Response.json()` returns `Any`, which leaks through the declared return type. Bind to a typed local first so the return is a real `dict[str, Any]`.

## Test plan

- [x] `uv run ruff check src/ scripts/` — clean (ignoring the UP017 in unrelated WIP `run_syn_rbl_full.py`)
- [x] `uv run mypy src/` — `Success: no issues found in 46 source files`
- [ ] CI `test` job (Lint + Typecheck + tests) goes green

## Out of scope

- The UP017 in `scripts/run_syn_rbl_full.py` (unstaged WIP, not on this branch).
- Any of the SYN-RBL changes in PR #3 — that lands separately once CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)