### PR TITLE
Fix aichemy balance uspto CLI: handle tuple return + apply confidence gate

### DIFF
--- a/src/aichemy/cli.py
+++ b/src/aichemy/cli.py
@@ -308,20 +308,43 @@ def balance_uspto(
 
     from aichemy.preprocessing.balance import syn_rbl as syn_rbl_module
 
+    # Trust deterministic SYN-RBL solves (rule-based / input-balanced report
+    # no confidence); require confidence > threshold for MCS-imputed solves
+    # where SYN-RBL is guessing missing compounds and can produce nonsense.
+    # Mirrors the gate applied in scripts/run_syn_rbl_full.py — keep in sync.
+    confidence_threshold = 0.8
+
     uspto_rows = reactions.filter(uspto_mask)
-    balanced = syn_rbl_module.balance_reactions(uspto_rows["reaction_smiles"].to_list())
-    # Replace the reaction_smiles column for balanced USPTO rows; drop
-    # rows the balancer couldn't fix (None).
-    fixed = uspto_rows.with_columns(pl.Series("reaction_smiles", balanced)).filter(
-        pl.col("reaction_smiles").is_not_null()
+    orig_smiles = uspto_rows["reaction_smiles"].to_list()
+    balance_results = syn_rbl_module.balance_reactions(orig_smiles)
+
+    # Gate: balanced=True iff SYN-RBL emitted a SMILES AND
+    # (confidence is None — deterministic solve — OR confidence > threshold).
+    # Keep all rows; replace `reaction_smiles` only when the gate passes,
+    # otherwise preserve the original USPTO SMILES so downstream stages can
+    # see the original patent claim.
+    balanced_bool = [
+        smi is not None and (conf is None or conf > confidence_threshold)
+        for smi, conf in balance_results
+    ]
+    new_rxn_smiles = [
+        smi if is_bal else orig
+        for orig, (smi, _conf), is_bal in zip(
+            orig_smiles, balance_results, balanced_bool, strict=True
+        )
+    ]
+    uspto_balanced = uspto_rows.with_columns(
+        pl.Series("reaction_smiles", new_rxn_smiles),
+        pl.Series("balanced", balanced_bool, dtype=pl.Boolean),
     )
+    n_recovered = sum(balanced_bool)
 
     other = reactions.filter(~uspto_mask)
-    merged = pl.concat([other, fixed], how="diagonal_relaxed")
+    merged = pl.concat([other, uspto_balanced], how="diagonal_relaxed")
     write_reactions(merged, output_path)
     typer.echo(
-        f"[balance uspto] balanced {fixed.height} of {uspto_count} USPTO rows "
-        f"(kept {merged.height} total)."
+        f"[balance uspto] balanced {n_recovered} of {uspto_count} USPTO rows "
+        f"at conf>{confidence_threshold} (kept {merged.height} total)."
     )
 
 


### PR DESCRIPTION
## Summary

Follow-up to #3. PR #3 changed `balance_reactions()` to return `list[tuple[str | None, float | None]]` and applied the `solved AND (conf is None OR conf > 0.8)` gate inside `scripts/run_syn_rbl_full.py`. But the DVC pipeline doesn't run that script — it runs `aichemy balance uspto`, which has its own copy of the consumer logic in `src/aichemy/cli.py:312`. That copy was left expecting the old `list[str | None]` shape.

Practically: any `dvc repro` that exercises the `balance_uspto` stage will crash on a `TypeError` as soon as polars tries to build a string Series from a list of tuples.

This PR ports the same gate the standalone script uses into the CLI command.

## Behavior changes vs. the old CLI version

- **Tuple return type handled.** No more crash.
- **Confidence gate applied.** `balanced=True` only when SYN-RBL emitted a SMILES *and* (confidence is None — i.e. deterministic rule-based / input-balanced solve — *or* confidence > 0.8). MCS-imputed solves at low confidence get rejected.
- **No longer drops unbalanced USPTO rows.** The previous CLI dropped any row where `balance_reactions()` returned `None`. New behavior matches the standalone script: keep the row, restore the original `reaction_smiles`, set `balanced=False`. Downstream stages now see the same row count regardless of which entry-point ran the balancer.
- **Sets the `balanced` column on USPTO rows.** The downstream `balance validate` stage overwrites this with an atom-count recompute, but populating it here keeps the schema honest mid-pipeline.

## Test plan

- [x] `uv run ruff check src/aichemy/cli.py` — clean
- [x] `uv run mypy src/aichemy/cli.py` — clean
- [x] `uv run pytest tests/unit -q` — 156 passed
- [ ] CI green
- [ ] Once merged, `uv run dvc repro --force normalize` cascades cleanly through balance_uspto → balance_validate → augment_yields → augment_thermo (USPTO skipped) → augment_directionality

## Out of scope

- Hoisting `confidence_threshold = 0.8` into a shared module so the CLI and standalone script can't drift. Worth doing as cleanup, but not in this PR.
- Re-running the actual pipeline. That's a separate user-driven step (~4h batch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)