### PR TITLE
normalize: drop molecules unreferenced by surviving reactions

### DIFF
--- a/src/aichemy/cli.py
+++ b/src/aichemy/cli.py
@@ -188,6 +188,7 @@ def normalize(
     filtered = normalize_module.filter_reactions_by_carbon(
         reactions, molecules, min_carbon=cfg.filter.min_carbon_count
     )
+    molecules = normalize_module.filter_molecules_by_usage(molecules, filtered)
 
     write_molecules(molecules, mol_out)
     write_reactions(filtered, rxn_out)

--- a/src/aichemy/preprocessing/normalize.py
+++ b/src/aichemy/preprocessing/normalize.py
@@ -149,3 +149,25 @@ def filter_reactions_by_carbon(
 
     mask = [_passes(row) for row in reactions.iter_rows(named=True)]
     return reactions.filter(pl.Series("_keep", mask, dtype=pl.Boolean))
+
+
+def filter_molecules_by_usage(
+    molecules: pl.DataFrame,
+    reactions: pl.DataFrame,
+) -> pl.DataFrame:
+    """Keep only molecules whose mol_id appears in some reaction's reactants or products."""
+    if reactions.height == 0:
+        return molecules.head(0)
+    referenced = (
+        pl.concat(
+            [
+                reactions.lazy().select(pl.col("reactants").alias("side")),
+                reactions.lazy().select(pl.col("products").alias("side")),
+            ]
+        )
+        .explode("side")
+        .select(pl.col("side").struct.field("mol_id"))
+        .unique()
+        .collect()
+    )
+    return molecules.join(referenced, on="mol_id", how="semi")

--- a/tests/unit/test_normalize.py
+++ b/tests/unit/test_normalize.py
@@ -6,6 +6,7 @@ import polars as pl
 
 from aichemy.preprocessing.normalize import (
     canonicalize_molecules,
+    filter_molecules_by_usage,
     filter_reactions_by_carbon,
     merge_sources,
 )
@@ -85,3 +86,55 @@ def test_filter_reactions_by_carbon_drops_sub_threshold() -> None:
     # r1 and r2 both have ≥1 high-carbon participant on each side → keep.
     # r3 has no carbon anywhere → drop.
     assert filtered["rxn_id"].to_list() == ["r1", "r2"]
+
+
+def test_filter_molecules_by_usage_keeps_only_referenced() -> None:
+    molecules = pl.DataFrame(
+        {
+            "mol_id": ["A", "B", "C", "ORPHAN"],
+            "canonical_smiles": ["CC", "CCO", "O", "N"],
+            "inchi_key": ["a", "b", "c", "d"],
+            "carbon_count": [2, 2, 0, 0],
+            "price_per_gram": [None, None, None, None],
+            "source_refs": [["x"], ["y"], ["z"], ["w"]],
+        },
+        schema_overrides={"carbon_count": pl.Int64, "price_per_gram": pl.Float64},
+    )
+    reactions = pl.DataFrame(
+        {
+            "rxn_id": ["r1"],
+            "reactants": [[{"mol_id": "A", "coefficient": 1.0}]],
+            "products": [
+                [
+                    {"mol_id": "B", "coefficient": 1.0},
+                    {"mol_id": "C", "coefficient": 1.0},
+                ]
+            ],
+        }
+    )
+    out = filter_molecules_by_usage(molecules, reactions)
+    assert sorted(out["mol_id"].to_list()) == ["A", "B", "C"]
+
+
+def test_filter_molecules_by_usage_empty_reactions_drops_all() -> None:
+    molecules = pl.DataFrame(
+        {
+            "mol_id": ["A"],
+            "canonical_smiles": ["CC"],
+            "inchi_key": ["a"],
+            "carbon_count": [2],
+            "price_per_gram": [None],
+            "source_refs": [["x"]],
+        },
+        schema_overrides={"carbon_count": pl.Int64, "price_per_gram": pl.Float64},
+    )
+    empty_rxns = pl.DataFrame(
+        schema={
+            "rxn_id": pl.Utf8,
+            "reactants": pl.List(pl.Struct({"mol_id": pl.Utf8, "coefficient": pl.Float64})),
+            "products": pl.List(pl.Struct({"mol_id": pl.Utf8, "coefficient": pl.Float64})),
+        }
+    )
+    out = filter_molecules_by_usage(molecules, empty_rxns)
+    assert out.height == 0
+    assert out.schema == molecules.schema


### PR DESCRIPTION
## Summary

- Adds `filter_molecules_by_usage` to `src/aichemy/preprocessing/normalize.py` — a single Polars semi-join that keeps only molecules whose `mol_id` appears in some reaction's `reactants` or `products`.
- Wires it into the `normalize` CLI command **after** `filter_reactions_by_carbon`, so molecules orphaned by dropped reactions also get pruned (not just molecules that were never referenced to begin with).
- Empty-reactions branch returns `molecules.head(0)` to preserve schema/dtypes (matches the existing `_empty_molecules` / `write_empty_molecules` convention).

## Why this placement

The original suggestion was "after merging sources." Running it post-carbon-filter prunes the strict superset of orphans — same ~10-line semi-join, just placed where it does the most work. The carbon filter still consults the full molecules table for lookups, so nothing is dropped before it runs.

## Test plan

- [x] `uv run pytest tests/unit/test_normalize.py tests/unit/test_uspto_normalize.py` — 9/9 pass (2 new tests cover the kept/orphan case and the empty-reactions schema preservation).
- [x] `uv run pytest tests/integration/test_full_pipeline.py` — passes; fixture has no orphan molecules so the existing `assert deduped_mols.height == molecules.height` invariant still holds.
- [ ] Spot-check on real data: `uv run aichemy normalize --config configs/default.toml` and confirm `data/interim/normalized/molecules.parquet` row count shrinks (never grows) by the count of carbon-filter orphans.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WodG6waKpXrDSw1psrUmfm)_