### PR TITLE
normalize: drop molecules unreferenced by surviving reactions (re-open of #7)

### DIFF
--- a/src/aichemy/cli.py
+++ b/src/aichemy/cli.py
@@ -188,6 +188,7 @@ def normalize(
     filtered = normalize_module.filter_reactions_by_carbon(
         reactions, molecules, min_carbon=cfg.filter.min_carbon_count
     )
+    molecules = normalize_module.filter_molecules_by_usage(molecules, filtered)
 
     write_molecules(molecules, mol_out)
     write_reactions(filtered, rxn_out)

--- a/src/aichemy/preprocessing/normalize.py
+++ b/src/aichemy/preprocessing/normalize.py
@@ -149,3 +149,25 @@ def filter_reactions_by_carbon(
 
     mask = [_passes(row) for row in reactions.iter_rows(named=True)]
     return reactions.filter(pl.Series("_keep", mask, dtype=pl.Boolean))
+
+
+def filter_molecules_by_usage(
+    molecules: pl.DataFrame,
+    reactions: pl.DataFrame,
+) -> pl.DataFrame:
+    """Keep only molecules whose mol_id appears in some reaction's reactants or products."""
+    if reactions.height == 0:
+        return molecules.head(0)
+    referenced = (
+        pl.concat(
+            [
+                reactions.lazy().select(pl.col("reactants").alias("side")),
+                reactions.lazy().select(pl.col("products").alias("side")),
+            ]
+        )
+        .explode("side")
+        .select(pl.col("side").struct.field("mol_id"))
+        .unique()
+        .collect()
+    )
+    return molecules.join(referenced, on="mol_id", how="semi")

--- a/tests/unit/test_normalize.py
+++ b/tests/unit/test_normalize.py
@@ -6,6 +6,7 @@ import polars as pl
 
 from aichemy.preprocessing.normalize import (
     canonicalize_molecules,
+    filter_molecules_by_usage,
     filter_reactions_by_carbon,
     merge_sources,
 )
@@ -85,3 +86,55 @@ def test_filter_reactions_by_carbon_drops_sub_threshold() -> None:
     # r1 and r2 both have ≥1 high-carbon participant on each side → keep.
     # r3 has no carbon anywhere → drop.
     assert filtered["rxn_id"].to_list() == ["r1", "r2"]
+
+
+def test_filter_molecules_by_usage_keeps_only_referenced() -> None:
+    molecules = pl.DataFrame(
+        {
+            "mol_id": ["A", "B", "C", "ORPHAN"],
+            "canonical_smiles": ["CC", "CCO", "O", "N"],
+            "inchi_key": ["a", "b", "c", "d"],
+            "carbon_count": [2, 2, 0, 0],
+            "price_per_gram": [None, None, None, None],
+            "source_refs": [["x"], ["y"], ["z"], ["w"]],
+        },
+        schema_overrides={"carbon_count": pl.Int64, "price_per_gram": pl.Float64},
+    )
+    reactions = pl.DataFrame(
+        {
+            "rxn_id": ["r1"],
+            "reactants": [[{"mol_id": "A", "coefficient": 1.0}]],
+            "products": [
+                [
+                    {"mol_id": "B", "coefficient": 1.0},
+                    {"mol_id": "C", "coefficient": 1.0},
+                ]
+            ],
+        }
+    )
+    out = filter_molecules_by_usage(molecules, reactions)
+    assert sorted(out["mol_id"].to_list()) == ["A", "B", "C"]
+
+
+def test_filter_molecules_by_usage_empty_reactions_drops_all() -> None:
+    molecules = pl.DataFrame(
+        {
+            "mol_id": ["A"],
+            "canonical_smiles": ["CC"],
+            "inchi_key": ["a"],
+            "carbon_count": [2],
+            "price_per_gram": [None],
+            "source_refs": [["x"]],
+        },
+        schema_overrides={"carbon_count": pl.Int64, "price_per_gram": pl.Float64},
+    )
+    empty_rxns = pl.DataFrame(
+        schema={
+            "rxn_id": pl.Utf8,
+            "reactants": pl.List(pl.Struct({"mol_id": pl.Utf8, "coefficient": pl.Float64})),
+            "products": pl.List(pl.Struct({"mol_id": pl.Utf8, "coefficient": pl.Float64})),
+        }
+    )
+    out = filter_molecules_by_usage(molecules, empty_rxns)
+    assert out.height == 0
+    assert out.schema == molecules.schema


### PR DESCRIPTION
Re-opens the work originally landed in #7 and reverted in `9a83914`.

## Why this PR exists

PR #7 was merged prematurely while still in draft. After review, the policy this PR introduces (drop **any** molecule not referenced by a reaction) was found to overlap with in-progress local work in `src/aichemy/preprocessing/chem/resolve_class.py:drop_unreferenced_empty_molecules`, which applies a **narrower** policy (drop only molecules that are *both* empty SMILES *and* unreferenced). The merge was reverted on main so a deliberate policy decision can be made between:

- **Aggressive** (this PR's `filter_molecules_by_usage`): drop any molecule that no surviving reaction touches
- **Conservative** (local Ralph work's `drop_unreferenced_empty_molecules`): preserve all rows with structural data, drop only the ~35K MetaNetX cross-ref entries that are both empty AND unreferenced

The ultimate fix may be one, the other, or a layered combination. Re-opening here so iteration can continue without contention with `main`.

## Cross-reference

Runs in parallel with the (also reverted) #9 work — `balance uspto: chunked + n_jobs=-1`. Both touched disjoint code paths (this PR: `normalize.py`; #9: `cli.py:balance_uspto` + `scripts/run_syn_rbl_full.py`), so they can be sequenced or merged independently once iteration completes.

## Original Summary (preserved verbatim from #7)

- Adds `filter_molecules_by_usage` to `src/aichemy/preprocessing/normalize.py` — a single Polars semi-join that keeps only molecules whose `mol_id` appears in some reaction's `reactants` or `products`.
- Wires it into the `normalize` CLI command **after** `filter_reactions_by_carbon`, so molecules orphaned by dropped reactions also get pruned.
- Empty-reactions branch returns `molecules.head(0)` to preserve schema/dtypes.

## Test plan

- [x] `uv run pytest tests/unit/test_normalize.py` (carried over from #7)
- [x] `uv run pytest tests/integration/test_full_pipeline.py` (carried over from #7)
- [ ] Reconcile policy with `drop_unreferenced_empty_molecules` in local resolve_class.py work — pick one or compose them
- [ ] Spot-check on real data: `uv run aichemy normalize` and confirm row count change matches expectation

Original session: https://claude.ai/code/session_01WodG6waKpXrDSw1psrUmfm