### PR TITLE
balance: drop unbalanced rows + add rdkit_balanced strict-truth column

### DIFF
--- a/src/aichemy/cli.py
+++ b/src/aichemy/cli.py
@@ -416,13 +416,24 @@ def balance_uspto(
 
     other = reactions.filter(~uspto_mask)
     merged = pl.concat([other, uspto_balanced], how="diagonal_relaxed")
+
+    # Drop rows where balanced=False. For USPTO this means SYN-RBL didn't
+    # solve at confidence > threshold; for MetaNetX it means the source's
+    # is_balanced flag was 'N'. Keeping only balanced rows means downstream
+    # stages and the final processed parquet contain only mass-balanced
+    # reactions (per-source claim). The strict per-element atom-count check
+    # runs in balance_validate and writes its result to `rdkit_balanced`.
+    pre_drop = merged.height
+    merged = merged.filter(pl.col("balanced"))
+    dropped = pre_drop - merged.height
     write_reactions(merged, output_path)
 
     total_min = (time.time() - overall_start) / 60
     typer.echo(
         f"[balance uspto] DONE in {total_min:.1f} min: "
         f"balanced {n_recovered} of {uspto_count} USPTO rows "
-        f"at conf>{confidence_threshold} (kept {merged.height} total)."
+        f"at conf>{confidence_threshold}; "
+        f"dropped {dropped} unbalanced rows; kept {merged.height} balanced total."
     )
 
 
@@ -431,7 +442,7 @@ def balance_validate(
     config: Path = ConfigOpt,
     override: list[Path] = OverrideOpt,
 ) -> None:
-    """Universal atom-count validation; populates balanced: bool for all reactions."""
+    """Universal atom-count validation; populates rdkit_balanced: bool for all reactions."""
     cfg = _load(config, override)
     input_path = interim_path(cfg, "balanced", "reactions.parquet")
     output_path = interim_path(cfg, "validated", "reactions.parquet")
@@ -452,7 +463,8 @@ def balance_validate(
     write_reactions(validated, output_path)
     typer.echo(
         f"[balance validate] wrote {validated.height} rows "
-        f"({validated.filter(validated['balanced']).height} balanced)."
+        f"({validated.filter(validated['rdkit_balanced']).height} rdkit_balanced "
+        f"of {validated.filter(validated['balanced']).height} balanced)."
     )
 
 

--- a/src/aichemy/preprocessing/balance/validate.py
+++ b/src/aichemy/preprocessing/balance/validate.py
@@ -211,7 +211,11 @@ def validate_reactions(
         balanced_vals.append(False)
         keep_mask.append(unbalanced_policy != UnbalancedPolicy.DROP)
 
-    out = df.with_columns(pl.Series("balanced", balanced_vals, dtype=pl.Boolean))
+    # Write the strict atom-count result to `rdkit_balanced`. The upstream
+    # `balanced` column is preserved as-is — it carries the per-source
+    # claim (SYN-RBL conf>0.8 for USPTO, curator is_balanced=B for MetaNetX).
+    # `rdkit_balanced` is the trusted per-element mass-balance check.
+    out = df.with_columns(pl.Series("rdkit_balanced", balanced_vals, dtype=pl.Boolean))
     if unbalanced_policy == UnbalancedPolicy.DROP:
         out = out.filter(pl.Series("_keep", keep_mask, dtype=pl.Boolean))
     return out

--- a/src/aichemy/preprocessing/io.py
+++ b/src/aichemy/preprocessing/io.py
@@ -76,6 +76,7 @@ REACTION_SCHEMA = {
     "yield_rate": pl.Float64,
     "delta_g": pl.Float64,
     "balanced": pl.Boolean,
+    "rdkit_balanced": pl.Boolean,
     "source": pl.Utf8,
 }
 

--- a/src/aichemy/preprocessing/sources/metanetx.py
+++ b/src/aichemy/preprocessing/sources/metanetx.py
@@ -133,6 +133,7 @@ def ingest_metanetx(fixture_dir: Path) -> tuple[pl.DataFrame, pl.DataFrame]:
         pl.lit(None, dtype=pl.Float64).alias("yield_rate"),
         pl.lit(None, dtype=pl.Float64).alias("delta_g"),
         pl.col("balanced_mnx").alias("balanced"),
+        pl.lit(False).cast(pl.Boolean).alias("rdkit_balanced"),
         pl.lit("metanetx").alias("source"),
         pl.col("ec_class"),
         # MetaNetX's `reac_prop.tsv` does not carry an explicit direction flag

--- a/src/aichemy/preprocessing/sources/uspto.py
+++ b/src/aichemy/preprocessing/sources/uspto.py
@@ -122,6 +122,7 @@ def ingest_uspto(rsmi_path: Path) -> pl.DataFrame:
             "yield_rate": yield_rate,
             "delta_g": [None] * raw.height,
             "balanced": [False] * raw.height,
+            "rdkit_balanced": [False] * raw.height,
             "source": ["uspto"] * raw.height,
             "ec_class": [None] * raw.height,
         },
@@ -129,6 +130,7 @@ def ingest_uspto(rsmi_path: Path) -> pl.DataFrame:
             "yield_rate": pl.Float64,
             "delta_g": pl.Float64,
             "balanced": pl.Boolean,
+            "rdkit_balanced": pl.Boolean,
             "ec_class": pl.Utf8,
         },
     )

--- a/tests/unit/test_balance_policy.py
+++ b/tests/unit/test_balance_policy.py
@@ -55,7 +55,7 @@ def test_validate_policy_flag_keeps_unbalanced_as_false() -> None:
     )
     out = validate_reactions(df, unbalanced_policy=UnbalancedPolicy.FLAG)
     assert out.height == 1
-    assert out["balanced"].to_list() == [False]
+    assert out["rdkit_balanced"].to_list() == [False]
 
 
 def test_validate_policy_drop_removes_unbalanced() -> None:
@@ -86,4 +86,4 @@ def test_validate_policy_heuristic_h_flips_proton_imbalance_to_true() -> None:
         }
     )
     out = validate_reactions(df, unbalanced_policy=UnbalancedPolicy.HEURISTIC_H)
-    assert out["balanced"].to_list() == [True]
+    assert out["rdkit_balanced"].to_list() == [True]

--- a/tests/unit/test_balance_validate.py
+++ b/tests/unit/test_balance_validate.py
@@ -57,7 +57,7 @@ def test_is_balanced_ignores_hydrogens_when_configured() -> None:
     assert is_balanced(reactants, products, ignore_elements=["H"]) is True
 
 
-def test_validate_reactions_adds_balanced_column() -> None:
+def test_validate_reactions_adds_rdkit_balanced_column() -> None:
     df = pl.DataFrame(
         {
             "rxn_id": ["r1", "r2"],
@@ -75,4 +75,4 @@ def test_validate_reactions_adds_balanced_column() -> None:
         }
     )
     out = validate_reactions(df)
-    assert out["balanced"].to_list() == [True, False]
+    assert out["rdkit_balanced"].to_list() == [True, False]

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -139,5 +139,6 @@ def test_write_empty_reactions_is_readable(tmp_path: Path) -> None:
         "yield_rate",
         "delta_g",
         "balanced",
+        "rdkit_balanced",
         "source",
     }


### PR DESCRIPTION
## Why

Today the `balanced` column in `data/processed/reactions.parquet` is misleading: `balance_uspto` keeps all rows and marks ~30% as `balanced=True` (SYN-RBL conf > 0.8); `balance_validate` then **overwrites** that flag based on its own atom-count math, so the final value is the strict-validate result with no audit trail of the SYN-RBL claim. And the dropped rows that nobody wants to consume (~80% of USPTO that SYN-RBL couldn't solve) still ride through every downstream stage.

## What changes

**Schema (`REACTION_SCHEMA` in `io.py`)** — adds `rdkit_balanced: pl.Boolean` between `balanced` and `source`. Both flags now coexist:

| Field | Set by | Meaning |
|---|---|---|
| `balanced` | metanetx ingest (curator's `is_balanced`) / `balance_uspto` (SYN-RBL conf > 0.8) | per-source claim |
| `rdkit_balanced` | `balance_validate` (independent atom-count math) | strict mass-balance truth |

**`balance_uspto` now drops `balanced=False` rows at the end of the stage.** This means the rest of the pipeline only operates on rows the per-source claim said were balanced. Subset proof: 196 → 58 rows.

**`balance_validate` writes to the new `rdkit_balanced` column instead of overwriting `balanced`.** Subset proof: 3 of the 58 surviving rows are `rdkit_balanced=True` (~5%, consistent with the previous 10/196 ratio).

## Files changed

- `src/aichemy/preprocessing/io.py` — schema +`rdkit_balanced`
- `src/aichemy/preprocessing/sources/{metanetx,uspto}.py` — emit `rdkit_balanced=False` at ingest
- `src/aichemy/cli.py:balance_uspto` — drop unbalanced rows, log dropped count
- `src/aichemy/cli.py:balance_validate` — log `X rdkit_balanced of Y balanced`
- `src/aichemy/preprocessing/balance/validate.py` — write `rdkit_balanced`, preserve upstream `balanced`
- `tests/unit/test_{balance_policy,balance_validate,io}.py` — assert on new column

## Solver

`src/aichemy/solver/model.py:91` still filters on `balanced`. With the new semantics that means the solver sees **all 58 SYN-RBL-claimed rows** instead of the **10 atom-validated** rows it saw before. If strict mass-balance in the MILP matters, swap to `rdkit_balanced` in a follow-up. Left as-is here to keep the schema change atomic.

## Test plan

- [x] `uv run pytest tests/unit/` — 182 passed
- [x] Full subset pipeline runs end-to-end (`bash scripts/build_subset.sh && uv run aichemy ingest metanetx → ... → export`):
  - balance_uspto: `balanced 58 of 196 USPTO rows at conf>0.8; dropped 138 unbalanced rows; kept 58 balanced total`
  - balance_validate: `wrote 58 rows (3 rdkit_balanced of 58 balanced)`
  - export: `wrote 58 reactions, 493 molecules, manifest -> data_subset/processed/hypergraph_manifest.json`
- [ ] Full-data run: deferred (balance_uspto ~4hr + augment_thermo ~1-2hr)