### PR TITLE
solver: add --balance-filter CLI flag (rdkit_balanced default)

### DIFF
--- a/src/aichemy/solver/cli.py
+++ b/src/aichemy/solver/cli.py
@@ -30,6 +30,14 @@ _VerboseOpt = typer.Option(False, "--verbose")
 _OutputOpt = typer.Option(
     None, "--output", help="JSON output path (default: data/processed/solution.json)"
 )
+_BalanceFilterOpt = typer.Option(
+    "rdkit_balanced",
+    "--balance-filter",
+    help=(
+        "Which boolean column gates reactions: 'rdkit_balanced' (default, "
+        "strict atom-count) or 'balanced' (looser per-source claim)."
+    ),
+)
 
 
 @solver_app.command("run")
@@ -41,6 +49,7 @@ def solve(
     backend: str = _BackendOpt,
     verbose: bool = _VerboseOpt,
     output: Path | None = _OutputOpt,
+    balance_filter: str = _BalanceFilterOpt,
 ) -> None:
     """Solve the profit-maximization MILP on `data/processed/`."""
     cfg = load_config(config, override)
@@ -50,6 +59,7 @@ def solve(
         backend=backend,  # type: ignore[arg-type]
         verbose=verbose,
         output_path=output or processed_path(cfg, "solution.json"),
+        balance_filter=balance_filter,  # type: ignore[arg-type]
     )
 
     reactions = read_reactions(processed_path(cfg, "reactions.parquet"))

--- a/src/aichemy/solver/config.py
+++ b/src/aichemy/solver/config.py
@@ -31,6 +31,15 @@ class SolverConfig(BaseModel):
     # Typically ≤ buy price to prevent arbitrage from gaps.
     default_sell_price: float = 0.0
 
+    # Which boolean column gates which reactions enter the MILP.
+    # "rdkit_balanced" (default, strict): per-element atom-count equality
+    #   verified by RDKit in the balance_validate stage.
+    # "balanced" (looser): per-source claim — SYN-RBL conf > 0.8 for USPTO,
+    #   curator's is_balanced=='B' for MetaNetX. After the drop_unbalanced
+    #   stage every surviving row has balanced=True, so this is effectively
+    #   "no atom-count filter".
+    balance_filter: Literal["balanced", "rdkit_balanced"] = "rdkit_balanced"
+
     # Minimum non-zero flow when a reaction is activated (prevents
     # "epsilon-activations" that win the objective by cents).
     min_flow: float = 1e-3

--- a/src/aichemy/solver/model.py
+++ b/src/aichemy/solver/model.py
@@ -81,14 +81,17 @@ def build_and_solve(
 ) -> Solution:
     """Build the MILP, solve it, return the Solution.
 
-    Only considers ``balanced=True`` reactions. Uses ``price_per_gram`` from
-    molecules; falls back to ``config.default_{buy,sell}_price`` for
-    unpriced molecules.
+    Filters reactions to those with ``config.balance_filter == True`` (default
+    ``rdkit_balanced``; ``balanced`` for the looser per-source claim). Uses
+    ``price_per_gram`` from molecules; falls back to
+    ``config.default_{buy,sell}_price`` for unpriced molecules.
     """
     # Filter to balanced reactions only — unbalanced rows would violate mass
-    # conservation in the MILP.
-    if "balanced" in reactions.columns:
-        reactions = reactions.filter(pl.col("balanced"))
+    # conservation in the MILP. Column choice (strict rdkit_balanced vs looser
+    # balanced) is selectable via SolverConfig.balance_filter.
+    col = config.balance_filter
+    if col in reactions.columns:
+        reactions = reactions.filter(pl.col(col))
     if reactions.height == 0:
         return Solution("No reactions after filtering", 0.0, [], [], [])
 

--- a/tests/integration/test_solver_scaling.py
+++ b/tests/integration/test_solver_scaling.py
@@ -44,7 +44,9 @@ def test_solver_handles_1000_reactions() -> None:
     """1k-reaction subset should solve in well under a minute."""
     _skip_if_no_real_data()
 
-    reactions = pl.read_parquet(PROCESSED_DIR / "reactions.parquet").filter(pl.col("balanced"))
+    reactions = pl.read_parquet(PROCESSED_DIR / "reactions.parquet").filter(
+        pl.col("rdkit_balanced")
+    )
     all_molecules = pl.read_parquet(PROCESSED_DIR / "molecules.parquet")
 
     sample = reactions.sample(n=min(1000, reactions.height), seed=42)
@@ -74,7 +76,9 @@ def test_solver_handles_full_balanced_network() -> None:
     """
     _skip_if_no_real_data()
 
-    reactions = pl.read_parquet(PROCESSED_DIR / "reactions.parquet").filter(pl.col("balanced"))
+    reactions = pl.read_parquet(PROCESSED_DIR / "reactions.parquet").filter(
+        pl.col("rdkit_balanced")
+    )
     all_molecules = pl.read_parquet(PROCESSED_DIR / "molecules.parquet")
 
     referenced: set[str] = set()

--- a/tests/integration/test_solver_validation.py
+++ b/tests/integration/test_solver_validation.py
@@ -35,6 +35,7 @@ def _reactions(rows: list[dict]) -> pl.DataFrame:
         r.setdefault("yield_rate", 1.0)  # use 1.0 so arithmetic is trivial
         r.setdefault("type", "chemical")
         r.setdefault("balanced", True)
+        r.setdefault("rdkit_balanced", True)
         r.setdefault("source", "test")
         r.setdefault("delta_g", None)
         r.setdefault("reaction_smiles", ">>")
@@ -169,12 +170,14 @@ def test_activated_reactions_are_always_from_balanced_set() -> None:
                 "reactants": [{"mol_id": "A", "coefficient": 1.0}],
                 "products": [{"mol_id": "B", "coefficient": 1.0}],
                 "balanced": True,
+                "rdkit_balanced": True,
             },
             {
                 "rxn_id": "r_unbal",
                 "reactants": [{"mol_id": "A", "coefficient": 1.0}],
                 "products": [{"mol_id": "C", "coefficient": 1.0}],
                 "balanced": False,
+                "rdkit_balanced": False,
             },
         ]
     )

--- a/tests/unit/test_solver.py
+++ b/tests/unit/test_solver.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import polars as pl
+import pytest
 
 from aichemy.solver.config import SolverConfig
 from aichemy.solver.model import build_and_solve
@@ -29,6 +30,7 @@ def _sample_reactions(reactions: list[dict]) -> pl.DataFrame:
         r.setdefault("yield_rate", 0.9)
         r.setdefault("type", "chemical")
         r.setdefault("balanced", True)
+        r.setdefault("rdkit_balanced", True)
         r.setdefault("source", "test")
         r.setdefault("delta_g", None)
         r.setdefault("reaction_smiles", ">>")
@@ -75,6 +77,7 @@ def test_unbalanced_reactions_excluded() -> None:
                 "reactants": [{"mol_id": "A", "coefficient": 1.0}],
                 "products": [{"mol_id": "B", "coefficient": 1.0}],
                 "balanced": False,
+                "rdkit_balanced": False,
             },
         ]
     )
@@ -82,6 +85,39 @@ def test_unbalanced_reactions_excluded() -> None:
     solution = build_and_solve(reactions, molecules, SolverConfig())
     assert solution.objective_value == 0.0
     assert "filtering" in solution.status or solution.activated_reactions == []
+
+
+@pytest.mark.parametrize(
+    "filter_col,row_balanced,row_rdkit,expect_activated",
+    [
+        ("rdkit_balanced", True, False, False),  # strict drops it
+        ("balanced", True, False, True),  # loose keeps it
+        ("rdkit_balanced", True, True, True),
+        ("balanced", False, True, False),
+    ],
+)
+def test_balance_filter_selects_column(
+    filter_col: str,
+    row_balanced: bool,
+    row_rdkit: bool,
+    expect_activated: bool,
+) -> None:
+    reactions = _sample_reactions(
+        [
+            {
+                "rxn_id": "r1",
+                "reactants": [{"mol_id": "A", "coefficient": 1.0}],
+                "products": [{"mol_id": "B", "coefficient": 1.0}],
+                "balanced": row_balanced,
+                "rdkit_balanced": row_rdkit,
+            },
+        ]
+    )
+    molecules = _sample_molecules({"A": 1.0, "B": 10.0})
+    cfg = SolverConfig(budget=100.0, balance_filter=filter_col)  # type: ignore[arg-type]
+    sol = build_and_solve(reactions, molecules, cfg)
+    activated = {r["rxn_id"] for r in sol.activated_reactions}
+    assert ("r1" in activated) is expect_activated
 
 
 def test_budget_constraint_caps_purchases() -> None:


### PR DESCRIPTION
Closes #16.

## Why

After PR #15 reframed `balanced` as a per-source claim and PR #17 added the `drop_unbalanced` DVC stage, every row in `data/processed/reactions.parquet` has `balanced=True`. The solver's filter `pl.col("balanced")` (`solver/model.py:90-91`) became a no-op, so rows whose atom counts don't actually match could enter the MILP and violate mass conservation.

## What

- `SolverConfig.balance_filter: Literal["balanced", "rdkit_balanced"] = "rdkit_balanced"` — strict by default; `balanced` is the explicit looser opt-in.
- `aichemy solve run --balance-filter {balanced,rdkit_balanced}` threads the choice through typer → pydantic.
- `build_and_solve` filters on `config.balance_filter` instead of the hardcoded `"balanced"`.
- Existing solver test fixtures default `rdkit_balanced=True` so the new strict default doesn't drop happy-path rows.
- New `test_balance_filter_selects_column` parametrized test proves the knob picks which column gates the row.
- `test_solver_scaling.py` reads now filter on `rdkit_balanced` (the on-disk `balanced` column is uniformly `True` post-`drop_unbalanced`).

## Test plan

- [x] `uv run pytest tests/unit/test_solver.py tests/integration/test_solver_validation.py -q` — 15 passed.
- [x] `uv run ruff check` + `ruff format --check` on the touched files — all clean.
- [x] `uv run aichemy solve run --help` shows `--balance-filter [default: rdkit_balanced]` with the strict-vs-loose help text.
- [ ] (Optional, requires `./scripts/build_subset.sh`) End-to-end smoke: default vs `--balance-filter balanced` on the subset parquet — expect activated count to grow under loose mode.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XtHuKdpoo1qHB2gvWH2YSA)_