### PR TITLE
licensing B: PatentsView fetch + CPC classifier (Tasks 6–9)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dev = [
     "nbstripout",
     "dvc>=3.0",
     "responses>=0.25",
+    "types-requests>=2.31",
 ]
 
 [tool.ruff]

--- a/src/aichemy/cli.py
+++ b/src/aichemy/cli.py
@@ -18,6 +18,7 @@ from aichemy.preprocessing.augment.directionality import DirectionalityMode
 from aichemy.preprocessing.balance import validate as balance_validate_module
 from aichemy.preprocessing.io import (
     interim_path,
+    licenses_path,
     patents_path,
     processed_path,
     raw_path,
@@ -642,6 +643,37 @@ def patents_fetch(
 
     n_ok = sum(1 for p in items if p.fetch_status == "ok")
     typer.echo(f"[patents fetch] wrote {len(items)} rows ({n_ok} ok) → {out_path}")
+
+
+@patents_app.command("classify-cpc")
+def patents_classify_cpc(
+    config: Path = ConfigOpt,
+    override: list[Path] = OverrideOpt,
+) -> None:
+    """Classify each (rxn_id, patent) pair via CPC-code rules."""
+    from datetime import date
+
+    from aichemy.preprocessing.patents.cpc import (
+        classify_dataframe,
+        load_cpc_rules,
+    )
+
+    cfg = _load(config, override)
+    reactions = read_reactions(interim_path(cfg, "augmented", "reactions_full.parquet"))
+    patents = pl.read_parquet(patents_path(cfg, "patent_metadata.parquet"))
+    rules = load_cpc_rules(cfg.licenses.cpc_rules_path)
+
+    out = classify_dataframe(reactions, patents, rules=rules, today=date.today())
+    out_path = licenses_path(cfg, "cpc_classifications.parquet")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out.write_parquet(out_path)
+
+    n_ambig = int(out["cpc_ambiguous"].sum())
+    n_active = int(out["patent_active"].sum())
+    typer.echo(
+        f"[patents classify-cpc] {out.height} rows "
+        f"({n_active} active, {n_ambig} ambiguous → LLM) → {out_path}"
+    )
 
 
 @app.command("export")

--- a/src/aichemy/cli.py
+++ b/src/aichemy/cli.py
@@ -18,6 +18,7 @@ from aichemy.preprocessing.augment.directionality import DirectionalityMode
 from aichemy.preprocessing.balance import validate as balance_validate_module
 from aichemy.preprocessing.io import (
     interim_path,
+    patents_path,
     processed_path,
     raw_path,
     read_molecules,
@@ -34,10 +35,12 @@ ingest_app = typer.Typer(help="Ingest raw data from a source.")
 dedup_app = typer.Typer(help="Deduplicate molecules or reactions.")
 balance_app = typer.Typer(help="Balance and validate reaction atom counts.")
 augment_app = typer.Typer(help="Enrich the merged table with yields, prices, directionality.")
+patents_app = typer.Typer(help="Patent metadata fetching and license classification.")
 app.add_typer(ingest_app, name="ingest")
 app.add_typer(dedup_app, name="dedup")
 app.add_typer(balance_app, name="balance")
 app.add_typer(augment_app, name="augment")
+app.add_typer(patents_app, name="patents")
 app.add_typer(solver_app, name="solve")
 
 
@@ -608,6 +611,37 @@ def augment_directionality(
         augmented = df  # nothing to do without direction annotation
     write_reactions(augmented, output_path)
     typer.echo(f"[augment directionality] wrote {augmented.height} rows.")
+
+
+@patents_app.command("fetch")
+def patents_fetch(
+    config: Path = ConfigOpt,
+    override: list[Path] = OverrideOpt,
+) -> None:
+    """Fetch PatentsView metadata for every USPTO patent referenced by reactions."""
+    from aichemy.preprocessing.patents.fetch import (
+        fetch_patents,
+        write_metadata_parquet,
+    )
+
+    cfg = _load(config, override)
+    reactions = read_reactions(interim_path(cfg, "augmented", "reactions_full.parquet"))
+
+    uspto_rxns = reactions.filter(pl.col("source") == "uspto")
+    patent_numbers = sorted({rid.split(":")[1] for rid in uspto_rxns["rxn_id"].to_list()})
+    typer.echo(f"[patents fetch] {len(patent_numbers)} unique USPTO patents to fetch")
+
+    items = fetch_patents(
+        patent_numbers,
+        endpoint=cfg.licenses.patentsview_endpoint,
+        max_retries=cfg.licenses.fetch_max_retries,
+        batch_size=cfg.licenses.fetch_batch_size,
+    )
+    out_path = patents_path(cfg, "patent_metadata.parquet")
+    write_metadata_parquet(items, out_path)
+
+    n_ok = sum(1 for p in items if p.fetch_status == "ok")
+    typer.echo(f"[patents fetch] wrote {len(items)} rows ({n_ok} ok) → {out_path}")
 
 
 @app.command("export")

--- a/src/aichemy/preprocessing/patents/__init__.py
+++ b/src/aichemy/preprocessing/patents/__init__.py
@@ -1,0 +1,1 @@
+"""Patent metadata fetching and license classification."""

--- a/src/aichemy/preprocessing/patents/cpc.py
+++ b/src/aichemy/preprocessing/patents/cpc.py
@@ -1,0 +1,149 @@
+"""CPC-code classifier for patent licensing.
+
+Pure function operating on a single patent's CPC codes + filing date,
+producing booleans that downstream stages consume. Rules are loaded from
+a YAML config so they can be tweaked without code changes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+
+import polars as pl
+import yaml
+
+PATENT_TERM_YEARS = 20
+
+
+@dataclass
+class CPCRules:
+    process_codes: list[str]
+    composition_codes: list[str]
+    ambiguous_codes: list[str]
+
+
+@dataclass
+class CPCClassification:
+    patent_active: bool
+    cpc_process_hit: bool
+    cpc_composition_hit: bool
+    cpc_ambiguous: bool
+    process_covered_cpc: bool
+    composition_covered_cpc: bool
+
+
+CPC_CLASSIFICATION_SCHEMA = {
+    "rxn_id": pl.Utf8,
+    "patent_number": pl.Utf8,
+    "patent_active": pl.Boolean,
+    "cpc_process_hit": pl.Boolean,
+    "cpc_composition_hit": pl.Boolean,
+    "cpc_ambiguous": pl.Boolean,
+    "process_covered_cpc": pl.Boolean,
+    "composition_covered_cpc": pl.Boolean,
+}
+
+
+def load_cpc_rules(path: Path) -> CPCRules:
+    with open(path) as f:
+        raw = yaml.safe_load(f) or {}
+    return CPCRules(
+        process_codes=list(raw.get("process_codes") or []),
+        composition_codes=list(raw.get("composition_codes") or []),
+        ambiguous_codes=list(raw.get("ambiguous_codes") or []),
+    )
+
+
+def classify_patent(
+    *,
+    cpc_codes: list[str],
+    filing_date_str: str | None,
+    today: date,
+    rules: CPCRules,
+) -> CPCClassification:
+    """Classify one patent. Inactive patents short-circuit to all-False."""
+    patent_active = _is_active(filing_date_str, today)
+    if not patent_active:
+        return CPCClassification(
+            patent_active=False,
+            cpc_process_hit=False,
+            cpc_composition_hit=False,
+            cpc_ambiguous=False,
+            process_covered_cpc=False,
+            composition_covered_cpc=False,
+        )
+
+    process_hit = _any_prefix_match(cpc_codes, rules.process_codes)
+    composition_hit = _any_prefix_match(cpc_codes, rules.composition_codes)
+    ambiguous_explicit = _any_prefix_match(cpc_codes, rules.ambiguous_codes)
+    has_any_chemistry = process_hit or composition_hit or ambiguous_explicit
+
+    ambiguous = ambiguous_explicit or (process_hit and composition_hit) or not has_any_chemistry
+
+    return CPCClassification(
+        patent_active=True,
+        cpc_process_hit=process_hit,
+        cpc_composition_hit=composition_hit,
+        cpc_ambiguous=ambiguous,
+        process_covered_cpc=process_hit and not ambiguous,
+        composition_covered_cpc=composition_hit and not ambiguous,
+    )
+
+
+def _any_prefix_match(codes: list[str], prefixes: list[str]) -> bool:
+    return any(c.startswith(p) for c in codes for p in prefixes)
+
+
+def _is_active(filing_date_str: str | None, today: date) -> bool:
+    if not filing_date_str:
+        return False
+    try:
+        filed = date.fromisoformat(filing_date_str)
+    except ValueError:
+        return False
+    expiry = date(filed.year + PATENT_TERM_YEARS, filed.month, filed.day)
+    return today < expiry
+
+
+def classify_dataframe(
+    reactions: pl.DataFrame,
+    patents: pl.DataFrame,
+    *,
+    rules: CPCRules,
+    today: date,
+) -> pl.DataFrame:
+    """Produce one row per (rxn_id, patent_number) for USPTO reactions."""
+    uspto = reactions.filter(pl.col("source") == "uspto")
+    rxn_rows = []
+    for rid in uspto["rxn_id"].to_list():
+        parts = rid.split(":")
+        if len(parts) >= 3 and parts[0] == "USPTO":
+            rxn_rows.append({"rxn_id": rid, "patent_number": parts[1]})
+    rxn_df = pl.DataFrame(rxn_rows, schema={"rxn_id": pl.Utf8, "patent_number": pl.Utf8})
+
+    joined = rxn_df.join(patents, on="patent_number", how="left")
+
+    out_rows: list[dict] = []
+    for r in joined.iter_rows(named=True):
+        cpc_codes = list(r.get("cpc_codes") or [])
+        c = classify_patent(
+            cpc_codes=cpc_codes,
+            filing_date_str=r.get("filing_date"),
+            today=today,
+            rules=rules,
+        )
+        out_rows.append(
+            {
+                "rxn_id": r["rxn_id"],
+                "patent_number": r["patent_number"],
+                "patent_active": c.patent_active,
+                "cpc_process_hit": c.cpc_process_hit,
+                "cpc_composition_hit": c.cpc_composition_hit,
+                "cpc_ambiguous": c.cpc_ambiguous,
+                "process_covered_cpc": c.process_covered_cpc,
+                "composition_covered_cpc": c.composition_covered_cpc,
+            }
+        )
+    return pl.DataFrame(out_rows, schema=CPC_CLASSIFICATION_SCHEMA)

--- a/src/aichemy/preprocessing/patents/cpc.py
+++ b/src/aichemy/preprocessing/patents/cpc.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
+from typing import Any
 
 import polars as pl
 import yaml
@@ -125,7 +126,7 @@ def classify_dataframe(
 
     joined = rxn_df.join(patents, on="patent_number", how="left")
 
-    out_rows: list[dict] = []
+    out_rows: list[dict[str, Any]] = []
     for r in joined.iter_rows(named=True):
         cpc_codes = list(r.get("cpc_codes") or [])
         c = classify_patent(

--- a/src/aichemy/preprocessing/patents/fetch.py
+++ b/src/aichemy/preprocessing/patents/fetch.py
@@ -11,6 +11,7 @@ import logging
 import time
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import polars as pl
 import requests
@@ -30,7 +31,7 @@ class PatentMetadata:
     fetch_status: str  # "ok" | "not_found" | "error"
 
 
-PATENT_METADATA_SCHEMA = {
+PATENT_METADATA_SCHEMA: dict[str, Any] = {
     "patent_number": pl.Utf8,
     "filing_date": pl.Utf8,
     "grant_date": pl.Utf8,
@@ -108,7 +109,7 @@ def _fetch_batch(
     return [_error_record(pn) for pn in batch]
 
 
-def _parse_response(body: dict, batch: list[str]) -> list[PatentMetadata]:
+def _parse_response(body: dict[str, Any], batch: list[str]) -> list[PatentMetadata]:
     by_id: dict[str, PatentMetadata] = {}
     for p in body.get("patents") or []:
         pn = str(p.get("patent_number"))

--- a/src/aichemy/preprocessing/patents/fetch.py
+++ b/src/aichemy/preprocessing/patents/fetch.py
@@ -1,0 +1,180 @@
+"""PatentsView REST client.
+
+Fetches patent metadata (filing date, abstract, claims, CPC codes) for the
+USPTO patent numbers extracted from reaction `rxn_id`s. Used by the
+`fetch_patent_metadata` DVC stage.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import polars as pl
+import requests
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class PatentMetadata:
+    patent_number: str
+    filing_date: str | None
+    grant_date: str | None
+    abstract: str | None
+    claims_text: str | None
+    cpc_codes: list[str]
+    assignee: str | None
+    fetch_status: str  # "ok" | "not_found" | "error"
+
+
+PATENT_METADATA_SCHEMA = {
+    "patent_number": pl.Utf8,
+    "filing_date": pl.Utf8,
+    "grant_date": pl.Utf8,
+    "abstract": pl.Utf8,
+    "claims_text": pl.Utf8,
+    "cpc_codes": pl.List(pl.Utf8),
+    "assignee": pl.Utf8,
+    "fetch_status": pl.Utf8,
+}
+
+
+def fetch_patents(
+    patent_numbers: list[str],
+    *,
+    endpoint: str,
+    max_retries: int = 3,
+    batch_size: int = 25,
+    backoff_seconds: float = 1.0,
+) -> list[PatentMetadata]:
+    """Fetch metadata for the given patent numbers.
+
+    PatentsView accepts a JSON POST with a query in its query DSL. We batch
+    requests to amortize round-trip cost, retry on transient errors, and
+    record `fetch_status="error"` on permanent failure (rather than raise,
+    so the pipeline doesn't crash).
+    """
+    out: list[PatentMetadata] = []
+    seen: set[str] = set()
+    for i in range(0, len(patent_numbers), batch_size):
+        batch = patent_numbers[i : i + batch_size]
+        results = _fetch_batch(batch, endpoint, max_retries, backoff_seconds)
+        for r in results:
+            seen.add(r.patent_number)
+            out.append(r)
+    for pn in patent_numbers:
+        if pn not in seen:
+            out.append(_error_record(pn))
+    return out
+
+
+def _fetch_batch(
+    batch: list[str],
+    endpoint: str,
+    max_retries: int,
+    backoff_seconds: float,
+) -> list[PatentMetadata]:
+    payload = {
+        "q": {"patent_number": batch},
+        "f": [
+            "patent_number",
+            "patent_date",
+            "patent_abstract",
+            "claims",
+            "cpcs",
+            "assignees",
+            "application",
+        ],
+        "o": {"per_page": len(batch)},
+    }
+    for attempt in range(max_retries):
+        try:
+            r = requests.post(endpoint, json=payload, timeout=30)
+            if r.status_code == 200:
+                return _parse_response(r.json(), batch)
+            if r.status_code in (429, 500, 502, 503, 504) and attempt < max_retries - 1:
+                time.sleep(backoff_seconds * (2**attempt))
+                continue
+            log.warning("PatentsView returned %s for batch=%s", r.status_code, batch[:3])
+            break
+        except requests.RequestException as exc:
+            log.warning("PatentsView request failed (attempt %d): %s", attempt + 1, exc)
+            if attempt < max_retries - 1:
+                time.sleep(backoff_seconds * (2**attempt))
+                continue
+    return [_error_record(pn) for pn in batch]
+
+
+def _parse_response(body: dict, batch: list[str]) -> list[PatentMetadata]:
+    by_id: dict[str, PatentMetadata] = {}
+    for p in body.get("patents") or []:
+        pn = str(p.get("patent_number"))
+        claims_text = " ".join(c.get("text", "") for c in (p.get("claims") or []))
+        cpc_codes = [c.get("cpc_group_id", "") for c in (p.get("cpcs") or [])]
+        cpc_codes = [c for c in cpc_codes if c]
+        assignees = p.get("assignees") or []
+        assignee = assignees[0].get("assignee_organization") if assignees else None
+        application = p.get("application") or {}
+        by_id[pn] = PatentMetadata(
+            patent_number=pn,
+            filing_date=application.get("filing_date"),
+            grant_date=p.get("patent_date"),
+            abstract=p.get("patent_abstract"),
+            claims_text=claims_text or None,
+            cpc_codes=cpc_codes,
+            assignee=assignee,
+            fetch_status="ok",
+        )
+    out: list[PatentMetadata] = []
+    for pn in batch:
+        if pn in by_id:
+            out.append(by_id[pn])
+        else:
+            out.append(
+                PatentMetadata(
+                    patent_number=pn,
+                    filing_date=None,
+                    grant_date=None,
+                    abstract=None,
+                    claims_text=None,
+                    cpc_codes=[],
+                    assignee=None,
+                    fetch_status="not_found",
+                )
+            )
+    return out
+
+
+def _error_record(patent_number: str) -> PatentMetadata:
+    return PatentMetadata(
+        patent_number=patent_number,
+        filing_date=None,
+        grant_date=None,
+        abstract=None,
+        claims_text=None,
+        cpc_codes=[],
+        assignee=None,
+        fetch_status="error",
+    )
+
+
+def write_metadata_parquet(items: list[PatentMetadata], path: Path) -> None:
+    rows = [
+        {
+            "patent_number": p.patent_number,
+            "filing_date": p.filing_date,
+            "grant_date": p.grant_date,
+            "abstract": p.abstract,
+            "claims_text": p.claims_text,
+            "cpc_codes": p.cpc_codes,
+            "assignee": p.assignee,
+            "fetch_status": p.fetch_status,
+        }
+        for p in items
+    ]
+    df = pl.DataFrame(rows, schema=PATENT_METADATA_SCHEMA)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df.write_parquet(path)

--- a/tests/fixtures/cpc_rules_test.yaml
+++ b/tests/fixtures/cpc_rules_test.yaml
@@ -1,0 +1,8 @@
+process_codes:
+  - "C07B"
+  - "C07C"
+composition_codes:
+  - "C07D"
+  - "C07K"
+ambiguous_codes:
+  - "A61K"

--- a/tests/fixtures/patents/sample_patentsview_response.json
+++ b/tests/fixtures/patents/sample_patentsview_response.json
@@ -1,0 +1,25 @@
+{
+  "patents": [
+    {
+      "patent_number": "7456123",
+      "patent_date": "2008-11-25",
+      "patent_abstract": "A method for the synthesis of substituted heterocyclic compounds...",
+      "claims": [{"text": "1. A process for preparing a compound of formula I..."}],
+      "cpcs": [
+        {"cpc_group_id": "C07D 401/12"},
+        {"cpc_group_id": "A61K 31/505"}
+      ],
+      "assignees": [{"assignee_organization": "Acme Pharmaceuticals"}],
+      "application": {"filing_date": "2005-03-14"}
+    },
+    {
+      "patent_number": "9999999",
+      "patent_date": null,
+      "patent_abstract": null,
+      "claims": [],
+      "cpcs": [],
+      "assignees": [],
+      "application": {"filing_date": "1985-01-01"}
+    }
+  ]
+}

--- a/tests/unit/test_patents_cpc.py
+++ b/tests/unit/test_patents_cpc.py
@@ -1,0 +1,136 @@
+from datetime import date
+from pathlib import Path
+
+import polars as pl
+
+from aichemy.preprocessing.patents.cpc import (
+    CPC_CLASSIFICATION_SCHEMA,
+    CPCRules,
+    classify_dataframe,
+    classify_patent,
+    load_cpc_rules,
+)
+
+RULES_PATH = Path(__file__).parent.parent / "fixtures" / "cpc_rules_test.yaml"
+
+
+def _rules() -> CPCRules:
+    return load_cpc_rules(RULES_PATH)
+
+
+def test_inactive_patent_short_circuits():
+    today = date(2026, 4, 25)
+    out = classify_patent(
+        cpc_codes=["C07D 401/12"],
+        filing_date_str="1985-01-01",
+        today=today,
+        rules=_rules(),
+    )
+    assert out.patent_active is False
+    assert out.process_covered_cpc is False
+    assert out.composition_covered_cpc is False
+    assert out.cpc_ambiguous is False
+
+
+def test_active_process_only():
+    today = date(2026, 4, 25)
+    out = classify_patent(
+        cpc_codes=["C07C 1/00"],
+        filing_date_str="2015-06-01",
+        today=today,
+        rules=_rules(),
+    )
+    assert out.patent_active is True
+    assert out.cpc_process_hit is True
+    assert out.cpc_composition_hit is False
+    assert out.cpc_ambiguous is False
+    assert out.process_covered_cpc is True
+    assert out.composition_covered_cpc is False
+
+
+def test_active_composition_only():
+    today = date(2026, 4, 25)
+    out = classify_patent(
+        cpc_codes=["C07D 401/12"],
+        filing_date_str="2015-06-01",
+        today=today,
+        rules=_rules(),
+    )
+    assert out.cpc_process_hit is False
+    assert out.cpc_composition_hit is True
+    assert out.cpc_ambiguous is False
+    assert out.process_covered_cpc is False
+    assert out.composition_covered_cpc is True
+
+
+def test_active_both_hit_is_ambiguous():
+    today = date(2026, 4, 25)
+    out = classify_patent(
+        cpc_codes=["C07C 1/00", "C07D 401/12"],
+        filing_date_str="2015-06-01",
+        today=today,
+        rules=_rules(),
+    )
+    assert out.cpc_ambiguous is True
+    assert out.process_covered_cpc is False
+    assert out.composition_covered_cpc is False
+
+
+def test_active_a61k_is_ambiguous():
+    today = date(2026, 4, 25)
+    out = classify_patent(
+        cpc_codes=["A61K 31/505"],
+        filing_date_str="2015-06-01",
+        today=today,
+        rules=_rules(),
+    )
+    assert out.cpc_ambiguous is True
+
+
+def test_active_no_chemistry_codes_is_ambiguous():
+    today = date(2026, 4, 25)
+    out = classify_patent(
+        cpc_codes=["G06F 17/00"],
+        filing_date_str="2015-06-01",
+        today=today,
+        rules=_rules(),
+    )
+    assert out.cpc_ambiguous is True
+
+
+def test_missing_filing_date_treated_inactive():
+    today = date(2026, 4, 25)
+    out = classify_patent(
+        cpc_codes=["C07D"],
+        filing_date_str=None,
+        today=today,
+        rules=_rules(),
+    )
+    assert out.patent_active is False
+
+
+def test_classify_dataframe_joins_reactions_and_patents():
+    today = date(2026, 4, 25)
+    rules = _rules()
+    reactions = pl.DataFrame(
+        {
+            "rxn_id": ["USPTO:7456123:0", "USPTO:1985111:0", "MNXR1"],
+            "source": ["uspto", "uspto", "metanetx"],
+        }
+    )
+    patents = pl.DataFrame(
+        {
+            "patent_number": ["7456123", "1985111"],
+            "filing_date": ["2015-06-01", "1985-01-01"],
+            "cpc_codes": [["C07D 401/12"], ["C07D 401/12"]],
+        }
+    )
+    out = classify_dataframe(reactions, patents, rules=rules, today=today)
+    assert out.height == 2
+    by_rxn = {r["rxn_id"]: r for r in out.iter_rows(named=True)}
+    assert by_rxn["USPTO:7456123:0"]["patent_active"] is True
+    assert by_rxn["USPTO:7456123:0"]["composition_covered_cpc"] is True
+    assert by_rxn["USPTO:1985111:0"]["patent_active"] is False
+    for col, dtype in CPC_CLASSIFICATION_SCHEMA.items():
+        assert col in out.columns
+        assert out.schema[col] == dtype

--- a/tests/unit/test_patents_fetch.py
+++ b/tests/unit/test_patents_fetch.py
@@ -1,0 +1,78 @@
+import json
+from pathlib import Path
+
+import polars as pl
+import responses
+
+from aichemy.preprocessing.patents.fetch import (
+    PatentMetadata,
+    fetch_patents,
+    write_metadata_parquet,
+)
+
+FIXTURE = Path(__file__).parent.parent / "fixtures" / "patents" / "sample_patentsview_response.json"
+ENDPOINT = "https://search.patentsview.org/api/v1/patent"
+
+
+@responses.activate
+def test_fetch_patents_returns_metadata_objects():
+    responses.add(
+        responses.POST,
+        ENDPOINT,
+        json=json.loads(FIXTURE.read_text()),
+        status=200,
+    )
+    out = fetch_patents(["7456123", "9999999"], endpoint=ENDPOINT, max_retries=1)
+    assert len(out) == 2
+    by_id = {p.patent_number: p for p in out}
+    assert by_id["7456123"].filing_date == "2005-03-14"
+    assert by_id["7456123"].abstract.startswith("A method")
+    assert "C07D 401/12" in by_id["7456123"].cpc_codes
+    assert by_id["7456123"].claims_text.startswith("1. A process")
+    assert by_id["7456123"].fetch_status == "ok"
+    assert by_id["9999999"].abstract is None
+    assert by_id["9999999"].fetch_status == "ok"
+
+
+@responses.activate
+def test_fetch_patents_records_error_status_after_retry_exhaustion():
+    responses.add(responses.POST, ENDPOINT, status=500)
+    out = fetch_patents(["7456123"], endpoint=ENDPOINT, max_retries=2)
+    assert len(out) == 1
+    assert out[0].fetch_status == "error"
+
+
+def test_patent_metadata_dataclass_shape():
+    p = PatentMetadata(
+        patent_number="123",
+        filing_date="2010-01-01",
+        grant_date=None,
+        abstract=None,
+        claims_text=None,
+        cpc_codes=[],
+        assignee=None,
+        fetch_status="ok",
+    )
+    assert p.patent_number == "123"
+
+
+def test_write_metadata_parquet(tmp_path: Path):
+    items = [
+        PatentMetadata(
+            patent_number="123",
+            filing_date="2010-01-01",
+            grant_date="2012-06-15",
+            abstract="abc",
+            claims_text="1. claim",
+            cpc_codes=["C07D"],
+            assignee="X Inc",
+            fetch_status="ok",
+        ),
+    ]
+    out = tmp_path / "patents.parquet"
+    write_metadata_parquet(items, out)
+    df = pl.read_parquet(out)
+    assert df.height == 1
+    assert df["patent_number"][0] == "123"
+    assert df["cpc_codes"][0].to_list() == ["C07D"]
+    assert df["fetch_status"][0] == "ok"

--- a/uv.lock
+++ b/uv.lock
@@ -64,6 +64,7 @@ dev = [
     { name = "pytest-httpx" },
     { name = "responses" },
     { name = "ruff" },
+    { name = "types-requests" },
 ]
 
 [package.metadata]
@@ -102,6 +103,7 @@ dev = [
     { name = "pytest-httpx", specifier = ">=0.36" },
     { name = "responses", specifier = ">=0.25" },
     { name = "ruff", specifier = ">=0.4" },
+    { name = "types-requests", specifier = ">=2.31" },
 ]
 
 [[package]]
@@ -5756,6 +5758,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.33.0.20260408"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/6a/749dc53a54a3f35842c1f8197b3ca6b54af6d7458a1bfc75f6629b6da666/types_requests-2.33.0.20260408.tar.gz", hash = "sha256:95b9a86376807a216b2fb412b47617b202091c3ea7c078f47cc358d5528ccb7b", size = 23882, upload-time = "2026-04-08T04:34:49.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/b8/78fd6c037de4788c040fdd323b3369804400351b7827473920f6c1d03c10/types_requests-2.33.0.20260408-py3-none-any.whl", hash = "sha256:81f31d5ea4acb39f03be7bc8bed569ba6d5a9c5d97e89f45ac43d819b68ca50f", size = 20739, upload-time = "2026-04-08T04:34:48.325Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Tasks 6–9 of `docs/superpowers/plans/2026-04-25-aichemy-pricing-licensing.md`. Builds the rule-based half of the licensing pipeline on top of PR A's `LicensesConfig` + path helpers + reaction-schema columns.

- **Task 6**: `src/aichemy/preprocessing/patents/fetch.py` — `PatentMetadata` dataclass + `fetch_patents()` PatentsView REST client. Batched (`batch_size=25` default), retries on `429/500/502/503/504` with exponential backoff, records `fetch_status="error"` on permanent failure rather than raising.
- **Task 7**: `write_metadata_parquet()` keyed off `PATENT_METADATA_SCHEMA`, plus a new `patents_app` Typer group and `aichemy patents fetch` subcommand. Reads `interim/augmented/reactions_full.parquet`, parses `USPTO:{pn}:{idx}` rxn_ids, writes `interim/patents/patent_metadata.parquet`.
- **Task 8**: `src/aichemy/preprocessing/patents/cpc.py` — pure `classify_patent()` function with the 7-branch rule matrix (inactive short-circuit, process-only, composition-only, both-hit ambiguous, explicit-ambiguous-list, no-chemistry-codes ambiguous, missing-filing-date inactive). 20-year patent term. Rules load from `configs/cpc_rules.yaml`.
- **Task 9**: `classify_dataframe()` (USPTO-only join + per-row `classify_patent` call) + `aichemy patents classify-cpc` subcommand → `interim/licenses/cpc_classifications.parquet`.

No LLM, no DVC wiring — those land in PR C+. Mocks PatentsView via the `responses` lib; no live network in tests.

## Test plan
- [x] `uv run pytest tests/unit/test_patents_fetch.py tests/unit/test_patents_cpc.py -v` → 12 tests pass (4 + 8)
- [x] `uv run pytest` → only the 2 pre-existing `test_balance_syn_rbl` failures remain (optional `synrbl` extra missing in this env; predates this PR)
- [x] `uv run aichemy patents --help` lists `fetch` + `classify-cpc`
- [x] `uv run aichemy patents fetch --help` and `uv run aichemy patents classify-cpc --help` show `--config`/`--override`
- [x] `uv run ruff check` + `ruff format --check` clean on touched files

https://claude.ai/code/session_01UPDDqrs8qkkuo9oeAJhHuD

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPDDqrs8qkkuo9oeAJhHuD)_