### PR TITLE
licensing C: LLM patent classifier + classify-llm CLI (Tasks 10–13)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dev = [
     "nbstripout",
     "dvc>=3.0",
     "responses>=0.25",
+    "types-requests>=2.31",
 ]
 
 [tool.ruff]

--- a/src/aichemy/cli.py
+++ b/src/aichemy/cli.py
@@ -18,6 +18,7 @@ from aichemy.preprocessing.augment.directionality import DirectionalityMode
 from aichemy.preprocessing.balance import validate as balance_validate_module
 from aichemy.preprocessing.io import (
     interim_path,
+    licenses_path,
     patents_path,
     processed_path,
     raw_path,
@@ -642,6 +643,37 @@ def patents_fetch(
 
     n_ok = sum(1 for p in items if p.fetch_status == "ok")
     typer.echo(f"[patents fetch] wrote {len(items)} rows ({n_ok} ok) → {out_path}")
+
+
+@patents_app.command("classify-cpc")
+def patents_classify_cpc(
+    config: Path = ConfigOpt,
+    override: list[Path] = OverrideOpt,
+) -> None:
+    """Classify each (rxn_id, patent) pair via CPC-code rules."""
+    from datetime import date
+
+    from aichemy.preprocessing.patents.cpc import (
+        classify_dataframe,
+        load_cpc_rules,
+    )
+
+    cfg = _load(config, override)
+    reactions = read_reactions(interim_path(cfg, "augmented", "reactions_full.parquet"))
+    patents = pl.read_parquet(patents_path(cfg, "patent_metadata.parquet"))
+    rules = load_cpc_rules(cfg.licenses.cpc_rules_path)
+
+    out = classify_dataframe(reactions, patents, rules=rules, today=date.today())
+    out_path = licenses_path(cfg, "cpc_classifications.parquet")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out.write_parquet(out_path)
+
+    n_ambig = int(out["cpc_ambiguous"].sum())
+    n_active = int(out["patent_active"].sum())
+    typer.echo(
+        f"[patents classify-cpc] {out.height} rows "
+        f"({n_active} active, {n_ambig} ambiguous → LLM) → {out_path}"
+    )
 
 
 @app.command("export")

--- a/src/aichemy/cli.py
+++ b/src/aichemy/cli.py
@@ -676,6 +676,49 @@ def patents_classify_cpc(
     )
 
 
+@patents_app.command("classify-llm")
+def patents_classify_llm(
+    config: Path = ConfigOpt,
+    override: list[Path] = OverrideOpt,
+) -> None:
+    """Eagerly classify CPC-ambiguous active patents via Claude; cache results."""
+    import os
+
+    import anthropic
+
+    from aichemy.preprocessing.patents.llm_classify import (
+        classify_ambiguous_patents,
+    )
+
+    cfg = _load(config, override)
+    cpc = pl.read_parquet(licenses_path(cfg, "cpc_classifications.parquet"))
+    patents = pl.read_parquet(patents_path(cfg, "patent_metadata.parquet"))
+    reactions = read_reactions(interim_path(cfg, "augmented", "reactions_full.parquet"))
+
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        raise typer.BadParameter(
+            "ANTHROPIC_API_KEY not set; LLM classification cannot proceed."
+        )
+
+    client = anthropic.Anthropic()
+    out_path = licenses_path(cfg, "llm_classifications.parquet")
+    out = classify_ambiguous_patents(
+        cpc=cpc,
+        patents=patents,
+        reactions=reactions,
+        cache_path=cfg.licenses.cache_path,
+        out_path=out_path,
+        client=client,
+        model=cfg.licenses.llm_model,
+        max_retries=cfg.licenses.llm_max_retries,
+    )
+    n_hit = int(out["cache_hit"].sum())
+    typer.echo(
+        f"[patents classify-llm] {out.height} patents classified "
+        f"({n_hit} cache hits, {out.height - n_hit} fresh) → {out_path}"
+    )
+
+
 @app.command("export")
 def export(
     config: Path = ConfigOpt,

--- a/src/aichemy/cli.py
+++ b/src/aichemy/cli.py
@@ -18,6 +18,7 @@ from aichemy.preprocessing.augment.directionality import DirectionalityMode
 from aichemy.preprocessing.balance import validate as balance_validate_module
 from aichemy.preprocessing.io import (
     interim_path,
+    patents_path,
     processed_path,
     raw_path,
     read_molecules,
@@ -34,10 +35,12 @@ ingest_app = typer.Typer(help="Ingest raw data from a source.")
 dedup_app = typer.Typer(help="Deduplicate molecules or reactions.")
 balance_app = typer.Typer(help="Balance and validate reaction atom counts.")
 augment_app = typer.Typer(help="Enrich the merged table with yields, prices, directionality.")
+patents_app = typer.Typer(help="Patent metadata fetching and license classification.")
 app.add_typer(ingest_app, name="ingest")
 app.add_typer(dedup_app, name="dedup")
 app.add_typer(balance_app, name="balance")
 app.add_typer(augment_app, name="augment")
+app.add_typer(patents_app, name="patents")
 app.add_typer(solver_app, name="solve")
 
 
@@ -608,6 +611,37 @@ def augment_directionality(
         augmented = df  # nothing to do without direction annotation
     write_reactions(augmented, output_path)
     typer.echo(f"[augment directionality] wrote {augmented.height} rows.")
+
+
+@patents_app.command("fetch")
+def patents_fetch(
+    config: Path = ConfigOpt,
+    override: list[Path] = OverrideOpt,
+) -> None:
+    """Fetch PatentsView metadata for every USPTO patent referenced by reactions."""
+    from aichemy.preprocessing.patents.fetch import (
+        fetch_patents,
+        write_metadata_parquet,
+    )
+
+    cfg = _load(config, override)
+    reactions = read_reactions(interim_path(cfg, "augmented", "reactions_full.parquet"))
+
+    uspto_rxns = reactions.filter(pl.col("source") == "uspto")
+    patent_numbers = sorted({rid.split(":")[1] for rid in uspto_rxns["rxn_id"].to_list()})
+    typer.echo(f"[patents fetch] {len(patent_numbers)} unique USPTO patents to fetch")
+
+    items = fetch_patents(
+        patent_numbers,
+        endpoint=cfg.licenses.patentsview_endpoint,
+        max_retries=cfg.licenses.fetch_max_retries,
+        batch_size=cfg.licenses.fetch_batch_size,
+    )
+    out_path = patents_path(cfg, "patent_metadata.parquet")
+    write_metadata_parquet(items, out_path)
+
+    n_ok = sum(1 for p in items if p.fetch_status == "ok")
+    typer.echo(f"[patents fetch] wrote {len(items)} rows ({n_ok} ok) → {out_path}")
 
 
 @app.command("export")

--- a/src/aichemy/cli.py
+++ b/src/aichemy/cli.py
@@ -696,9 +696,7 @@ def patents_classify_llm(
     reactions = read_reactions(interim_path(cfg, "augmented", "reactions_full.parquet"))
 
     if not os.environ.get("ANTHROPIC_API_KEY"):
-        raise typer.BadParameter(
-            "ANTHROPIC_API_KEY not set; LLM classification cannot proceed."
-        )
+        raise typer.BadParameter("ANTHROPIC_API_KEY not set; LLM classification cannot proceed.")
 
     client = anthropic.Anthropic()
     out_path = licenses_path(cfg, "llm_classifications.parquet")

--- a/src/aichemy/preprocessing/patents/__init__.py
+++ b/src/aichemy/preprocessing/patents/__init__.py
@@ -1,0 +1,1 @@
+"""Patent metadata fetching and license classification."""

--- a/src/aichemy/preprocessing/patents/cache.py
+++ b/src/aichemy/preprocessing/patents/cache.py
@@ -1,0 +1,48 @@
+"""JSONL append-only cache for LLM patent classifications.
+
+One entry per LLM call. Cache key is `patent_number`. PatentsView is
+canonical (abstract/claims for a given patent_number are stable), so the
+cache hit on `patent_number` alone is correct.
+
+Append-only design means the file is human-readable, easy to inspect, and
+each invocation extends the file rather than rewriting it. On read, later
+entries with the same `patent_number` win.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+@dataclass
+class LLMCacheEntry:
+    patent_number: str
+    process_covered: bool
+    composition_covered: bool
+    confidence: float
+    rationale: str
+    model: str
+    ts: str
+
+
+def load_cache(path: Path) -> dict[str, LLMCacheEntry]:
+    """Read cache; later entries with the same patent_number win."""
+    if not path.exists():
+        return {}
+    out: dict[str, LLMCacheEntry] = {}
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            data = json.loads(line)
+            out[data["patent_number"]] = LLMCacheEntry(**data)
+    return out
+
+
+def append_cache(path: Path, entry: LLMCacheEntry) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a") as f:
+        f.write(json.dumps(asdict(entry)) + "\n")

--- a/src/aichemy/preprocessing/patents/cpc.py
+++ b/src/aichemy/preprocessing/patents/cpc.py
@@ -1,0 +1,149 @@
+"""CPC-code classifier for patent licensing.
+
+Pure function operating on a single patent's CPC codes + filing date,
+producing booleans that downstream stages consume. Rules are loaded from
+a YAML config so they can be tweaked without code changes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+
+import polars as pl
+import yaml
+
+PATENT_TERM_YEARS = 20
+
+
+@dataclass
+class CPCRules:
+    process_codes: list[str]
+    composition_codes: list[str]
+    ambiguous_codes: list[str]
+
+
+@dataclass
+class CPCClassification:
+    patent_active: bool
+    cpc_process_hit: bool
+    cpc_composition_hit: bool
+    cpc_ambiguous: bool
+    process_covered_cpc: bool
+    composition_covered_cpc: bool
+
+
+CPC_CLASSIFICATION_SCHEMA = {
+    "rxn_id": pl.Utf8,
+    "patent_number": pl.Utf8,
+    "patent_active": pl.Boolean,
+    "cpc_process_hit": pl.Boolean,
+    "cpc_composition_hit": pl.Boolean,
+    "cpc_ambiguous": pl.Boolean,
+    "process_covered_cpc": pl.Boolean,
+    "composition_covered_cpc": pl.Boolean,
+}
+
+
+def load_cpc_rules(path: Path) -> CPCRules:
+    with open(path) as f:
+        raw = yaml.safe_load(f) or {}
+    return CPCRules(
+        process_codes=list(raw.get("process_codes") or []),
+        composition_codes=list(raw.get("composition_codes") or []),
+        ambiguous_codes=list(raw.get("ambiguous_codes") or []),
+    )
+
+
+def classify_patent(
+    *,
+    cpc_codes: list[str],
+    filing_date_str: str | None,
+    today: date,
+    rules: CPCRules,
+) -> CPCClassification:
+    """Classify one patent. Inactive patents short-circuit to all-False."""
+    patent_active = _is_active(filing_date_str, today)
+    if not patent_active:
+        return CPCClassification(
+            patent_active=False,
+            cpc_process_hit=False,
+            cpc_composition_hit=False,
+            cpc_ambiguous=False,
+            process_covered_cpc=False,
+            composition_covered_cpc=False,
+        )
+
+    process_hit = _any_prefix_match(cpc_codes, rules.process_codes)
+    composition_hit = _any_prefix_match(cpc_codes, rules.composition_codes)
+    ambiguous_explicit = _any_prefix_match(cpc_codes, rules.ambiguous_codes)
+    has_any_chemistry = process_hit or composition_hit or ambiguous_explicit
+
+    ambiguous = ambiguous_explicit or (process_hit and composition_hit) or not has_any_chemistry
+
+    return CPCClassification(
+        patent_active=True,
+        cpc_process_hit=process_hit,
+        cpc_composition_hit=composition_hit,
+        cpc_ambiguous=ambiguous,
+        process_covered_cpc=process_hit and not ambiguous,
+        composition_covered_cpc=composition_hit and not ambiguous,
+    )
+
+
+def _any_prefix_match(codes: list[str], prefixes: list[str]) -> bool:
+    return any(c.startswith(p) for c in codes for p in prefixes)
+
+
+def _is_active(filing_date_str: str | None, today: date) -> bool:
+    if not filing_date_str:
+        return False
+    try:
+        filed = date.fromisoformat(filing_date_str)
+    except ValueError:
+        return False
+    expiry = date(filed.year + PATENT_TERM_YEARS, filed.month, filed.day)
+    return today < expiry
+
+
+def classify_dataframe(
+    reactions: pl.DataFrame,
+    patents: pl.DataFrame,
+    *,
+    rules: CPCRules,
+    today: date,
+) -> pl.DataFrame:
+    """Produce one row per (rxn_id, patent_number) for USPTO reactions."""
+    uspto = reactions.filter(pl.col("source") == "uspto")
+    rxn_rows = []
+    for rid in uspto["rxn_id"].to_list():
+        parts = rid.split(":")
+        if len(parts) >= 3 and parts[0] == "USPTO":
+            rxn_rows.append({"rxn_id": rid, "patent_number": parts[1]})
+    rxn_df = pl.DataFrame(rxn_rows, schema={"rxn_id": pl.Utf8, "patent_number": pl.Utf8})
+
+    joined = rxn_df.join(patents, on="patent_number", how="left")
+
+    out_rows: list[dict] = []
+    for r in joined.iter_rows(named=True):
+        cpc_codes = list(r.get("cpc_codes") or [])
+        c = classify_patent(
+            cpc_codes=cpc_codes,
+            filing_date_str=r.get("filing_date"),
+            today=today,
+            rules=rules,
+        )
+        out_rows.append(
+            {
+                "rxn_id": r["rxn_id"],
+                "patent_number": r["patent_number"],
+                "patent_active": c.patent_active,
+                "cpc_process_hit": c.cpc_process_hit,
+                "cpc_composition_hit": c.cpc_composition_hit,
+                "cpc_ambiguous": c.cpc_ambiguous,
+                "process_covered_cpc": c.process_covered_cpc,
+                "composition_covered_cpc": c.composition_covered_cpc,
+            }
+        )
+    return pl.DataFrame(out_rows, schema=CPC_CLASSIFICATION_SCHEMA)

--- a/src/aichemy/preprocessing/patents/cpc.py
+++ b/src/aichemy/preprocessing/patents/cpc.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
+from typing import Any
 
 import polars as pl
 import yaml
@@ -125,7 +126,7 @@ def classify_dataframe(
 
     joined = rxn_df.join(patents, on="patent_number", how="left")
 
-    out_rows: list[dict] = []
+    out_rows: list[dict[str, Any]] = []
     for r in joined.iter_rows(named=True):
         cpc_codes = list(r.get("cpc_codes") or [])
         c = classify_patent(

--- a/src/aichemy/preprocessing/patents/fetch.py
+++ b/src/aichemy/preprocessing/patents/fetch.py
@@ -11,6 +11,7 @@ import logging
 import time
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import polars as pl
 import requests
@@ -30,7 +31,7 @@ class PatentMetadata:
     fetch_status: str  # "ok" | "not_found" | "error"
 
 
-PATENT_METADATA_SCHEMA = {
+PATENT_METADATA_SCHEMA: dict[str, Any] = {
     "patent_number": pl.Utf8,
     "filing_date": pl.Utf8,
     "grant_date": pl.Utf8,
@@ -108,7 +109,7 @@ def _fetch_batch(
     return [_error_record(pn) for pn in batch]
 
 
-def _parse_response(body: dict, batch: list[str]) -> list[PatentMetadata]:
+def _parse_response(body: dict[str, Any], batch: list[str]) -> list[PatentMetadata]:
     by_id: dict[str, PatentMetadata] = {}
     for p in body.get("patents") or []:
         pn = str(p.get("patent_number"))

--- a/src/aichemy/preprocessing/patents/fetch.py
+++ b/src/aichemy/preprocessing/patents/fetch.py
@@ -1,0 +1,180 @@
+"""PatentsView REST client.
+
+Fetches patent metadata (filing date, abstract, claims, CPC codes) for the
+USPTO patent numbers extracted from reaction `rxn_id`s. Used by the
+`fetch_patent_metadata` DVC stage.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import polars as pl
+import requests
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class PatentMetadata:
+    patent_number: str
+    filing_date: str | None
+    grant_date: str | None
+    abstract: str | None
+    claims_text: str | None
+    cpc_codes: list[str]
+    assignee: str | None
+    fetch_status: str  # "ok" | "not_found" | "error"
+
+
+PATENT_METADATA_SCHEMA = {
+    "patent_number": pl.Utf8,
+    "filing_date": pl.Utf8,
+    "grant_date": pl.Utf8,
+    "abstract": pl.Utf8,
+    "claims_text": pl.Utf8,
+    "cpc_codes": pl.List(pl.Utf8),
+    "assignee": pl.Utf8,
+    "fetch_status": pl.Utf8,
+}
+
+
+def fetch_patents(
+    patent_numbers: list[str],
+    *,
+    endpoint: str,
+    max_retries: int = 3,
+    batch_size: int = 25,
+    backoff_seconds: float = 1.0,
+) -> list[PatentMetadata]:
+    """Fetch metadata for the given patent numbers.
+
+    PatentsView accepts a JSON POST with a query in its query DSL. We batch
+    requests to amortize round-trip cost, retry on transient errors, and
+    record `fetch_status="error"` on permanent failure (rather than raise,
+    so the pipeline doesn't crash).
+    """
+    out: list[PatentMetadata] = []
+    seen: set[str] = set()
+    for i in range(0, len(patent_numbers), batch_size):
+        batch = patent_numbers[i : i + batch_size]
+        results = _fetch_batch(batch, endpoint, max_retries, backoff_seconds)
+        for r in results:
+            seen.add(r.patent_number)
+            out.append(r)
+    for pn in patent_numbers:
+        if pn not in seen:
+            out.append(_error_record(pn))
+    return out
+
+
+def _fetch_batch(
+    batch: list[str],
+    endpoint: str,
+    max_retries: int,
+    backoff_seconds: float,
+) -> list[PatentMetadata]:
+    payload = {
+        "q": {"patent_number": batch},
+        "f": [
+            "patent_number",
+            "patent_date",
+            "patent_abstract",
+            "claims",
+            "cpcs",
+            "assignees",
+            "application",
+        ],
+        "o": {"per_page": len(batch)},
+    }
+    for attempt in range(max_retries):
+        try:
+            r = requests.post(endpoint, json=payload, timeout=30)
+            if r.status_code == 200:
+                return _parse_response(r.json(), batch)
+            if r.status_code in (429, 500, 502, 503, 504) and attempt < max_retries - 1:
+                time.sleep(backoff_seconds * (2**attempt))
+                continue
+            log.warning("PatentsView returned %s for batch=%s", r.status_code, batch[:3])
+            break
+        except requests.RequestException as exc:
+            log.warning("PatentsView request failed (attempt %d): %s", attempt + 1, exc)
+            if attempt < max_retries - 1:
+                time.sleep(backoff_seconds * (2**attempt))
+                continue
+    return [_error_record(pn) for pn in batch]
+
+
+def _parse_response(body: dict, batch: list[str]) -> list[PatentMetadata]:
+    by_id: dict[str, PatentMetadata] = {}
+    for p in body.get("patents") or []:
+        pn = str(p.get("patent_number"))
+        claims_text = " ".join(c.get("text", "") for c in (p.get("claims") or []))
+        cpc_codes = [c.get("cpc_group_id", "") for c in (p.get("cpcs") or [])]
+        cpc_codes = [c for c in cpc_codes if c]
+        assignees = p.get("assignees") or []
+        assignee = assignees[0].get("assignee_organization") if assignees else None
+        application = p.get("application") or {}
+        by_id[pn] = PatentMetadata(
+            patent_number=pn,
+            filing_date=application.get("filing_date"),
+            grant_date=p.get("patent_date"),
+            abstract=p.get("patent_abstract"),
+            claims_text=claims_text or None,
+            cpc_codes=cpc_codes,
+            assignee=assignee,
+            fetch_status="ok",
+        )
+    out: list[PatentMetadata] = []
+    for pn in batch:
+        if pn in by_id:
+            out.append(by_id[pn])
+        else:
+            out.append(
+                PatentMetadata(
+                    patent_number=pn,
+                    filing_date=None,
+                    grant_date=None,
+                    abstract=None,
+                    claims_text=None,
+                    cpc_codes=[],
+                    assignee=None,
+                    fetch_status="not_found",
+                )
+            )
+    return out
+
+
+def _error_record(patent_number: str) -> PatentMetadata:
+    return PatentMetadata(
+        patent_number=patent_number,
+        filing_date=None,
+        grant_date=None,
+        abstract=None,
+        claims_text=None,
+        cpc_codes=[],
+        assignee=None,
+        fetch_status="error",
+    )
+
+
+def write_metadata_parquet(items: list[PatentMetadata], path: Path) -> None:
+    rows = [
+        {
+            "patent_number": p.patent_number,
+            "filing_date": p.filing_date,
+            "grant_date": p.grant_date,
+            "abstract": p.abstract,
+            "claims_text": p.claims_text,
+            "cpc_codes": p.cpc_codes,
+            "assignee": p.assignee,
+            "fetch_status": p.fetch_status,
+        }
+        for p in items
+    ]
+    df = pl.DataFrame(rows, schema=PATENT_METADATA_SCHEMA)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df.write_parquet(path)

--- a/src/aichemy/preprocessing/patents/llm_classify.py
+++ b/src/aichemy/preprocessing/patents/llm_classify.py
@@ -8,8 +8,15 @@ tool-use schema to enforce structure rather than free-form JSON parsing.
 from __future__ import annotations
 
 import logging
+import time
 from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
+
+import polars as pl
+
+from aichemy.preprocessing.patents.cache import LLMCacheEntry, append_cache, load_cache
 
 log = logging.getLogger(__name__)
 
@@ -47,7 +54,9 @@ CLASSIFICATION_TOOL = {
             },
             "rationale": {
                 "type": "string",
-                "description": "One sentence citing the specific claim/passage that supports the answer.",
+                "description": (
+                    "One sentence citing the specific claim/passage that supports the answer."
+                ),
             },
         },
         "required": ["process_covered", "composition_covered", "confidence", "rationale"],
@@ -102,9 +111,7 @@ def classify_patent_llm(
         messages=[{"role": "user", "content": user}],
     )
     if msg.stop_reason != "tool_use":
-        log.warning(
-            "Unexpected stop_reason=%s for patent=%s", msg.stop_reason, patent_number
-        )
+        log.warning("Unexpected stop_reason=%s for patent=%s", msg.stop_reason, patent_number)
         return None
     for block in msg.content:
         if getattr(block, "type", None) == "tool_use" and block.name == "report_classification":
@@ -117,14 +124,6 @@ def classify_patent_llm(
             )
     return None
 
-
-import time
-from datetime import datetime, timezone
-from pathlib import Path
-
-import polars as pl
-
-from aichemy.preprocessing.patents.cache import LLMCacheEntry, append_cache, load_cache
 
 LLM_CLASSIFICATION_SCHEMA = {
     "patent_number": pl.Utf8,
@@ -204,7 +203,7 @@ def classify_ambiguous_patents(
             confidence=result.confidence,
             rationale=result.rationale,
             model=model,
-            ts=datetime.now(tz=timezone.utc).isoformat(),
+            ts=datetime.now(tz=UTC).isoformat(),
         )
         append_cache(cache_path, entry)
         rows.append(_to_row(entry, cache_hit=False))
@@ -252,7 +251,10 @@ def _call_with_retry(
         except Exception as exc:
             log.warning(
                 "LLM call failed (attempt %d/%d) for patent=%s: %s",
-                attempt + 1, max_retries, patent_number, exc,
+                attempt + 1,
+                max_retries,
+                patent_number,
+                exc,
             )
             if attempt < max_retries - 1:
                 time.sleep(backoff_seconds * (2**attempt))

--- a/src/aichemy/preprocessing/patents/llm_classify.py
+++ b/src/aichemy/preprocessing/patents/llm_classify.py
@@ -1,0 +1,118 @@
+"""LLM patent classifier using the Anthropic SDK with structured tool-use.
+
+The model is asked to judge two booleans (process_covered, composition_covered)
+plus a self-reported confidence and one-sentence rationale. We use Claude's
+tool-use schema to enforce structure rather than free-form JSON parsing.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+CLASSIFICATION_TOOL = {
+    "name": "report_classification",
+    "description": (
+        "Report whether the given patent's claims cover the synthesis route "
+        "(process) and/or any compound that participates in the reaction "
+        "(composition-of-matter)."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "process_covered": {
+                "type": "boolean",
+                "description": (
+                    "True iff the patent's INDEPENDENT claims cover this specific "
+                    "synthesis route (using these reactants, these conditions, this "
+                    "transformation). Mere disclosure in examples or background does NOT count."
+                ),
+            },
+            "composition_covered": {
+                "type": "boolean",
+                "description": (
+                    "True iff the patent's INDEPENDENT claims cover any participant "
+                    "compound (reactant, intermediate, or product) by composition-of-matter."
+                ),
+            },
+            "confidence": {
+                "type": "number",
+                "minimum": 0.0,
+                "maximum": 1.0,
+                "description": "Self-reported confidence in this classification.",
+            },
+            "rationale": {
+                "type": "string",
+                "description": "One sentence citing the specific claim/passage that supports the answer.",
+            },
+        },
+        "required": ["process_covered", "composition_covered", "confidence", "rationale"],
+    },
+}
+
+
+SYSTEM_PROMPT = (
+    "You are a patent-claims analyst. Given a USPTO patent's title, abstract, and "
+    "independent claims, plus example reaction SMILES extracted from the patent, decide "
+    "whether the patent's CLAIMS (not its background or examples) cover the reaction's "
+    "synthesis route (process) and/or any participant compound by composition-of-matter. "
+    "Be strict: only report True when the claims clearly cover the item. When in doubt, "
+    "report False with a low confidence."
+)
+
+
+@dataclass
+class LLMClassificationResult:
+    process_covered: bool
+    composition_covered: bool
+    confidence: float
+    rationale: str
+
+
+def classify_patent_llm(
+    *,
+    client: Any,
+    patent_number: str,
+    title: str | None,
+    abstract: str | None,
+    claims_text: str | None,
+    reaction_smiles_examples: list[str],
+    model: str,
+) -> LLMClassificationResult | None:
+    """One LLM call, one classification. Returns None on unexpected stop_reason."""
+    examples = "\n".join(reaction_smiles_examples[:5]) or "(none)"
+    user = (
+        f"Patent number: {patent_number}\n\n"
+        f"Title: {title or '(none)'}\n\n"
+        f"Abstract:\n{abstract or '(none)'}\n\n"
+        f"Independent claims:\n{(claims_text or '(none)')[:8000]}\n\n"
+        f"Reaction SMILES extracted from this patent:\n{examples}\n\n"
+        "Use the report_classification tool."
+    )
+    msg = client.messages.create(
+        model=model,
+        max_tokens=512,
+        system=SYSTEM_PROMPT,
+        tools=[CLASSIFICATION_TOOL],
+        tool_choice={"type": "tool", "name": "report_classification"},
+        messages=[{"role": "user", "content": user}],
+    )
+    if msg.stop_reason != "tool_use":
+        log.warning(
+            "Unexpected stop_reason=%s for patent=%s", msg.stop_reason, patent_number
+        )
+        return None
+    for block in msg.content:
+        if getattr(block, "type", None) == "tool_use" and block.name == "report_classification":
+            data = block.input
+            return LLMClassificationResult(
+                process_covered=bool(data["process_covered"]),
+                composition_covered=bool(data["composition_covered"]),
+                confidence=float(data["confidence"]),
+                rationale=str(data["rationale"]),
+            )
+    return None

--- a/src/aichemy/preprocessing/patents/llm_classify.py
+++ b/src/aichemy/preprocessing/patents/llm_classify.py
@@ -116,3 +116,156 @@ def classify_patent_llm(
                 rationale=str(data["rationale"]),
             )
     return None
+
+
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import polars as pl
+
+from aichemy.preprocessing.patents.cache import LLMCacheEntry, append_cache, load_cache
+
+LLM_CLASSIFICATION_SCHEMA = {
+    "patent_number": pl.Utf8,
+    "process_covered": pl.Boolean,
+    "composition_covered": pl.Boolean,
+    "confidence": pl.Float64,
+    "rationale": pl.Utf8,
+    "model": pl.Utf8,
+    "cache_hit": pl.Boolean,
+}
+
+
+def classify_ambiguous_patents(
+    *,
+    cpc: pl.DataFrame,
+    patents: pl.DataFrame,
+    reactions: pl.DataFrame,
+    cache_path: Path,
+    out_path: Path,
+    client: Any,
+    model: str,
+    max_retries: int = 3,
+    backoff_seconds: float = 1.0,
+) -> pl.DataFrame:
+    """Classify each unique patent flagged ambiguous + active.
+
+    Cache hits don't call the LLM. Misses call once per patent (no retries
+    on the LLM logic itself; transport-level retries on connection errors).
+    Failed calls fall back to (False, False, 0.0) and are NOT cached.
+    """
+    target_patents = (
+        cpc.filter(pl.col("cpc_ambiguous") & pl.col("patent_active"))
+        .select("patent_number")
+        .unique()["patent_number"]
+        .to_list()
+    )
+
+    cache = load_cache(cache_path)
+    rxn_smiles_by_patent = _smiles_index(cpc, reactions)
+    patent_meta = {r["patent_number"]: r for r in patents.iter_rows(named=True)}
+
+    rows: list[dict[str, Any]] = []
+    for pn in target_patents:
+        if pn in cache:
+            entry = cache[pn]
+            rows.append(_to_row(entry, cache_hit=True))
+            continue
+
+        meta = patent_meta.get(pn, {})
+        result = _call_with_retry(
+            client=client,
+            model=model,
+            patent_number=pn,
+            abstract=meta.get("abstract"),
+            claims_text=meta.get("claims_text"),
+            smiles_examples=rxn_smiles_by_patent.get(pn, []),
+            max_retries=max_retries,
+            backoff_seconds=backoff_seconds,
+        )
+        if result is None:
+            rows.append(
+                {
+                    "patent_number": pn,
+                    "process_covered": False,
+                    "composition_covered": False,
+                    "confidence": 0.0,
+                    "rationale": "LLM error — defaulted to no-license",
+                    "model": model,
+                    "cache_hit": False,
+                }
+            )
+            continue
+        entry = LLMCacheEntry(
+            patent_number=pn,
+            process_covered=result.process_covered,
+            composition_covered=result.composition_covered,
+            confidence=result.confidence,
+            rationale=result.rationale,
+            model=model,
+            ts=datetime.now(tz=timezone.utc).isoformat(),
+        )
+        append_cache(cache_path, entry)
+        rows.append(_to_row(entry, cache_hit=False))
+
+    df = pl.DataFrame(rows, schema=LLM_CLASSIFICATION_SCHEMA)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    df.write_parquet(out_path)
+    return df
+
+
+def _smiles_index(cpc: pl.DataFrame, reactions: pl.DataFrame) -> dict[str, list[str]]:
+    if "reaction_smiles" not in reactions.columns:
+        return {}
+    joined = cpc.select("rxn_id", "patent_number").join(
+        reactions.select("rxn_id", "reaction_smiles"), on="rxn_id", how="inner"
+    )
+    out: dict[str, list[str]] = {}
+    for r in joined.iter_rows(named=True):
+        out.setdefault(r["patent_number"], []).append(r["reaction_smiles"])
+    return out
+
+
+def _call_with_retry(
+    *,
+    client: Any,
+    model: str,
+    patent_number: str,
+    abstract: str | None,
+    claims_text: str | None,
+    smiles_examples: list[str],
+    max_retries: int,
+    backoff_seconds: float,
+) -> LLMClassificationResult | None:
+    for attempt in range(max_retries):
+        try:
+            return classify_patent_llm(
+                client=client,
+                patent_number=patent_number,
+                title=None,
+                abstract=abstract,
+                claims_text=claims_text,
+                reaction_smiles_examples=smiles_examples,
+                model=model,
+            )
+        except Exception as exc:
+            log.warning(
+                "LLM call failed (attempt %d/%d) for patent=%s: %s",
+                attempt + 1, max_retries, patent_number, exc,
+            )
+            if attempt < max_retries - 1:
+                time.sleep(backoff_seconds * (2**attempt))
+    return None
+
+
+def _to_row(entry: LLMCacheEntry, *, cache_hit: bool) -> dict[str, Any]:
+    return {
+        "patent_number": entry.patent_number,
+        "process_covered": entry.process_covered,
+        "composition_covered": entry.composition_covered,
+        "confidence": entry.confidence,
+        "rationale": entry.rationale,
+        "model": entry.model,
+        "cache_hit": cache_hit,
+    }

--- a/tests/fixtures/cpc_rules_test.yaml
+++ b/tests/fixtures/cpc_rules_test.yaml
@@ -1,0 +1,8 @@
+process_codes:
+  - "C07B"
+  - "C07C"
+composition_codes:
+  - "C07D"
+  - "C07K"
+ambiguous_codes:
+  - "A61K"

--- a/tests/fixtures/patents/sample_patentsview_response.json
+++ b/tests/fixtures/patents/sample_patentsview_response.json
@@ -1,0 +1,25 @@
+{
+  "patents": [
+    {
+      "patent_number": "7456123",
+      "patent_date": "2008-11-25",
+      "patent_abstract": "A method for the synthesis of substituted heterocyclic compounds...",
+      "claims": [{"text": "1. A process for preparing a compound of formula I..."}],
+      "cpcs": [
+        {"cpc_group_id": "C07D 401/12"},
+        {"cpc_group_id": "A61K 31/505"}
+      ],
+      "assignees": [{"assignee_organization": "Acme Pharmaceuticals"}],
+      "application": {"filing_date": "2005-03-14"}
+    },
+    {
+      "patent_number": "9999999",
+      "patent_date": null,
+      "patent_abstract": null,
+      "claims": [],
+      "cpcs": [],
+      "assignees": [],
+      "application": {"filing_date": "1985-01-01"}
+    }
+  ]
+}

--- a/tests/unit/test_patents_cpc.py
+++ b/tests/unit/test_patents_cpc.py
@@ -1,0 +1,136 @@
+from datetime import date
+from pathlib import Path
+
+import polars as pl
+
+from aichemy.preprocessing.patents.cpc import (
+    CPC_CLASSIFICATION_SCHEMA,
+    CPCRules,
+    classify_dataframe,
+    classify_patent,
+    load_cpc_rules,
+)
+
+RULES_PATH = Path(__file__).parent.parent / "fixtures" / "cpc_rules_test.yaml"
+
+
+def _rules() -> CPCRules:
+    return load_cpc_rules(RULES_PATH)
+
+
+def test_inactive_patent_short_circuits():
+    today = date(2026, 4, 25)
+    out = classify_patent(
+        cpc_codes=["C07D 401/12"],
+        filing_date_str="1985-01-01",
+        today=today,
+        rules=_rules(),
+    )
+    assert out.patent_active is False
+    assert out.process_covered_cpc is False
+    assert out.composition_covered_cpc is False
+    assert out.cpc_ambiguous is False
+
+
+def test_active_process_only():
+    today = date(2026, 4, 25)
+    out = classify_patent(
+        cpc_codes=["C07C 1/00"],
+        filing_date_str="2015-06-01",
+        today=today,
+        rules=_rules(),
+    )
+    assert out.patent_active is True
+    assert out.cpc_process_hit is True
+    assert out.cpc_composition_hit is False
+    assert out.cpc_ambiguous is False
+    assert out.process_covered_cpc is True
+    assert out.composition_covered_cpc is False
+
+
+def test_active_composition_only():
+    today = date(2026, 4, 25)
+    out = classify_patent(
+        cpc_codes=["C07D 401/12"],
+        filing_date_str="2015-06-01",
+        today=today,
+        rules=_rules(),
+    )
+    assert out.cpc_process_hit is False
+    assert out.cpc_composition_hit is True
+    assert out.cpc_ambiguous is False
+    assert out.process_covered_cpc is False
+    assert out.composition_covered_cpc is True
+
+
+def test_active_both_hit_is_ambiguous():
+    today = date(2026, 4, 25)
+    out = classify_patent(
+        cpc_codes=["C07C 1/00", "C07D 401/12"],
+        filing_date_str="2015-06-01",
+        today=today,
+        rules=_rules(),
+    )
+    assert out.cpc_ambiguous is True
+    assert out.process_covered_cpc is False
+    assert out.composition_covered_cpc is False
+
+
+def test_active_a61k_is_ambiguous():
+    today = date(2026, 4, 25)
+    out = classify_patent(
+        cpc_codes=["A61K 31/505"],
+        filing_date_str="2015-06-01",
+        today=today,
+        rules=_rules(),
+    )
+    assert out.cpc_ambiguous is True
+
+
+def test_active_no_chemistry_codes_is_ambiguous():
+    today = date(2026, 4, 25)
+    out = classify_patent(
+        cpc_codes=["G06F 17/00"],
+        filing_date_str="2015-06-01",
+        today=today,
+        rules=_rules(),
+    )
+    assert out.cpc_ambiguous is True
+
+
+def test_missing_filing_date_treated_inactive():
+    today = date(2026, 4, 25)
+    out = classify_patent(
+        cpc_codes=["C07D"],
+        filing_date_str=None,
+        today=today,
+        rules=_rules(),
+    )
+    assert out.patent_active is False
+
+
+def test_classify_dataframe_joins_reactions_and_patents():
+    today = date(2026, 4, 25)
+    rules = _rules()
+    reactions = pl.DataFrame(
+        {
+            "rxn_id": ["USPTO:7456123:0", "USPTO:1985111:0", "MNXR1"],
+            "source": ["uspto", "uspto", "metanetx"],
+        }
+    )
+    patents = pl.DataFrame(
+        {
+            "patent_number": ["7456123", "1985111"],
+            "filing_date": ["2015-06-01", "1985-01-01"],
+            "cpc_codes": [["C07D 401/12"], ["C07D 401/12"]],
+        }
+    )
+    out = classify_dataframe(reactions, patents, rules=rules, today=today)
+    assert out.height == 2
+    by_rxn = {r["rxn_id"]: r for r in out.iter_rows(named=True)}
+    assert by_rxn["USPTO:7456123:0"]["patent_active"] is True
+    assert by_rxn["USPTO:7456123:0"]["composition_covered_cpc"] is True
+    assert by_rxn["USPTO:1985111:0"]["patent_active"] is False
+    for col, dtype in CPC_CLASSIFICATION_SCHEMA.items():
+        assert col in out.columns
+        assert out.schema[col] == dtype

--- a/tests/unit/test_patents_fetch.py
+++ b/tests/unit/test_patents_fetch.py
@@ -1,0 +1,78 @@
+import json
+from pathlib import Path
+
+import polars as pl
+import responses
+
+from aichemy.preprocessing.patents.fetch import (
+    PatentMetadata,
+    fetch_patents,
+    write_metadata_parquet,
+)
+
+FIXTURE = Path(__file__).parent.parent / "fixtures" / "patents" / "sample_patentsview_response.json"
+ENDPOINT = "https://search.patentsview.org/api/v1/patent"
+
+
+@responses.activate
+def test_fetch_patents_returns_metadata_objects():
+    responses.add(
+        responses.POST,
+        ENDPOINT,
+        json=json.loads(FIXTURE.read_text()),
+        status=200,
+    )
+    out = fetch_patents(["7456123", "9999999"], endpoint=ENDPOINT, max_retries=1)
+    assert len(out) == 2
+    by_id = {p.patent_number: p for p in out}
+    assert by_id["7456123"].filing_date == "2005-03-14"
+    assert by_id["7456123"].abstract.startswith("A method")
+    assert "C07D 401/12" in by_id["7456123"].cpc_codes
+    assert by_id["7456123"].claims_text.startswith("1. A process")
+    assert by_id["7456123"].fetch_status == "ok"
+    assert by_id["9999999"].abstract is None
+    assert by_id["9999999"].fetch_status == "ok"
+
+
+@responses.activate
+def test_fetch_patents_records_error_status_after_retry_exhaustion():
+    responses.add(responses.POST, ENDPOINT, status=500)
+    out = fetch_patents(["7456123"], endpoint=ENDPOINT, max_retries=2)
+    assert len(out) == 1
+    assert out[0].fetch_status == "error"
+
+
+def test_patent_metadata_dataclass_shape():
+    p = PatentMetadata(
+        patent_number="123",
+        filing_date="2010-01-01",
+        grant_date=None,
+        abstract=None,
+        claims_text=None,
+        cpc_codes=[],
+        assignee=None,
+        fetch_status="ok",
+    )
+    assert p.patent_number == "123"
+
+
+def test_write_metadata_parquet(tmp_path: Path):
+    items = [
+        PatentMetadata(
+            patent_number="123",
+            filing_date="2010-01-01",
+            grant_date="2012-06-15",
+            abstract="abc",
+            claims_text="1. claim",
+            cpc_codes=["C07D"],
+            assignee="X Inc",
+            fetch_status="ok",
+        ),
+    ]
+    out = tmp_path / "patents.parquet"
+    write_metadata_parquet(items, out)
+    df = pl.read_parquet(out)
+    assert df.height == 1
+    assert df["patent_number"][0] == "123"
+    assert df["cpc_codes"][0].to_list() == ["C07D"]
+    assert df["fetch_status"][0] == "ok"

--- a/tests/unit/test_patents_llm_cache.py
+++ b/tests/unit/test_patents_llm_cache.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+from aichemy.preprocessing.patents.cache import (
+    LLMCacheEntry,
+    append_cache,
+    load_cache,
+)
+
+
+def test_load_cache_missing_file_returns_empty(tmp_path: Path):
+    cache_path = tmp_path / "cache.jsonl"
+    assert load_cache(cache_path) == {}
+
+
+def test_append_then_load_roundtrip(tmp_path: Path):
+    cache_path = tmp_path / "cache.jsonl"
+    e = LLMCacheEntry(
+        patent_number="123",
+        process_covered=True,
+        composition_covered=False,
+        confidence=0.9,
+        rationale="claim 1 covers a method",
+        model="claude-haiku-4-5",
+        ts="2026-04-25T00:00:00Z",
+    )
+    append_cache(cache_path, e)
+    loaded = load_cache(cache_path)
+    assert "123" in loaded
+    assert loaded["123"].process_covered is True
+
+
+def test_later_entry_wins_for_duplicate_keys(tmp_path: Path):
+    cache_path = tmp_path / "cache.jsonl"
+    e1 = LLMCacheEntry(
+        patent_number="X",
+        process_covered=False,
+        composition_covered=False,
+        confidence=0.5,
+        rationale="r1",
+        model="m1",
+        ts="2026-01-01T00:00:00Z",
+    )
+    e2 = LLMCacheEntry(
+        patent_number="X",
+        process_covered=True,
+        composition_covered=True,
+        confidence=0.9,
+        rationale="r2",
+        model="m1",
+        ts="2026-04-01T00:00:00Z",
+    )
+    append_cache(cache_path, e1)
+    append_cache(cache_path, e2)
+    loaded = load_cache(cache_path)
+    assert loaded["X"].process_covered is True
+    assert loaded["X"].rationale == "r2"

--- a/tests/unit/test_patents_llm_classify.py
+++ b/tests/unit/test_patents_llm_classify.py
@@ -1,0 +1,59 @@
+from unittest.mock import MagicMock
+
+from aichemy.preprocessing.patents.llm_classify import (
+    LLMClassificationResult,
+    classify_patent_llm,
+)
+
+
+def _stub_anthropic_response(*, process: bool, composition: bool, confidence: float, rationale: str):
+    """Build a mock that mimics anthropic.Anthropic().messages.create() returning tool-use."""
+    block = MagicMock()
+    block.type = "tool_use"
+    block.name = "report_classification"
+    block.input = {
+        "process_covered": process,
+        "composition_covered": composition,
+        "confidence": confidence,
+        "rationale": rationale,
+    }
+    msg = MagicMock()
+    msg.stop_reason = "tool_use"
+    msg.content = [block]
+    return msg
+
+
+def test_classify_patent_llm_parses_tool_use():
+    client = MagicMock()
+    client.messages.create.return_value = _stub_anthropic_response(
+        process=True, composition=False, confidence=0.86, rationale="claim 1 method",
+    )
+    out = classify_patent_llm(
+        client=client,
+        patent_number="7456123",
+        title="A method",
+        abstract="Method for synthesis…",
+        claims_text="1. A process for…",
+        reaction_smiles_examples=["A>>B"],
+        model="claude-haiku-4-5",
+    )
+    assert isinstance(out, LLMClassificationResult)
+    assert out.process_covered is True
+    assert out.composition_covered is False
+    assert out.confidence == 0.86
+    assert out.rationale.startswith("claim")
+
+
+def test_classify_patent_llm_returns_none_on_unexpected_stop_reason():
+    client = MagicMock()
+    msg = MagicMock()
+    msg.stop_reason = "end_turn"
+    msg.content = []
+    client.messages.create.return_value = msg
+    out = classify_patent_llm(
+        client=client,
+        patent_number="X",
+        title="t", abstract="a", claims_text="c", reaction_smiles_examples=[],
+        model="claude-haiku-4-5",
+    )
+    assert out is None

--- a/tests/unit/test_patents_llm_classify.py
+++ b/tests/unit/test_patents_llm_classify.py
@@ -57,3 +57,129 @@ def test_classify_patent_llm_returns_none_on_unexpected_stop_reason():
         model="claude-haiku-4-5",
     )
     assert out is None
+
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import polars as pl
+
+from aichemy.preprocessing.patents.cache import LLMCacheEntry, append_cache
+from aichemy.preprocessing.patents.llm_classify import (
+    LLM_CLASSIFICATION_SCHEMA,
+    classify_ambiguous_patents,
+)
+
+
+def test_classify_ambiguous_patents_uses_cache_when_present(tmp_path: Path):
+    cache_path = tmp_path / "cache.jsonl"
+    append_cache(
+        cache_path,
+        LLMCacheEntry(
+            patent_number="A",
+            process_covered=True,
+            composition_covered=False,
+            confidence=0.9,
+            rationale="cached",
+            model="claude-haiku-4-5",
+            ts=datetime.now(tz=timezone.utc).isoformat(),
+        ),
+    )
+    cpc = pl.DataFrame(
+        {
+            "rxn_id": ["USPTO:A:0"],
+            "patent_number": ["A"],
+            "patent_active": [True],
+            "cpc_ambiguous": [True],
+        }
+    )
+    patents = pl.DataFrame(
+        {
+            "patent_number": ["A"],
+            "abstract": ["x"],
+            "claims_text": ["1. claim"],
+            "cpc_codes": [["A61K"]],
+        }
+    )
+    reactions = pl.DataFrame({"rxn_id": ["USPTO:A:0"], "reaction_smiles": ["A>>B"]})
+    client = MagicMock()
+    out_path = tmp_path / "llm.parquet"
+    out_df = classify_ambiguous_patents(
+        cpc=cpc,
+        patents=patents,
+        reactions=reactions,
+        cache_path=cache_path,
+        out_path=out_path,
+        client=client,
+        model="claude-haiku-4-5",
+        max_retries=1,
+    )
+    assert client.messages.create.call_count == 0  # cache hit
+    assert out_df.height == 1
+    assert out_df["cache_hit"][0] is True
+    assert out_df["process_covered"][0] is True
+    for col, dtype in LLM_CLASSIFICATION_SCHEMA.items():
+        assert col in out_df.columns
+        assert out_df.schema[col] == dtype
+
+
+def test_classify_ambiguous_patents_calls_llm_on_cache_miss(tmp_path: Path):
+    cpc = pl.DataFrame(
+        {
+            "rxn_id": ["USPTO:B:0"],
+            "patent_number": ["B"],
+            "patent_active": [True],
+            "cpc_ambiguous": [True],
+        }
+    )
+    patents = pl.DataFrame(
+        {
+            "patent_number": ["B"],
+            "abstract": ["xyz"],
+            "claims_text": ["1. claim"],
+            "cpc_codes": [["A61K"]],
+        }
+    )
+    reactions = pl.DataFrame({"rxn_id": ["USPTO:B:0"], "reaction_smiles": ["A>>B"]})
+    client = MagicMock()
+    client.messages.create.return_value = _stub_anthropic_response(
+        process=False, composition=True, confidence=0.7, rationale="composition only",
+    )
+    cache_path = tmp_path / "cache.jsonl"
+    out_path = tmp_path / "llm.parquet"
+    out_df = classify_ambiguous_patents(
+        cpc=cpc, patents=patents, reactions=reactions,
+        cache_path=cache_path, out_path=out_path,
+        client=client, model="claude-haiku-4-5", max_retries=1,
+    )
+    assert client.messages.create.call_count == 1
+    assert out_df["cache_hit"][0] is False
+    assert out_df["composition_covered"][0] is True
+    # Cache file now has one entry
+    assert cache_path.exists()
+    assert "B" in cache_path.read_text()
+
+
+def test_classify_ambiguous_patents_skips_inactive(tmp_path: Path):
+    cpc = pl.DataFrame(
+        {
+            "rxn_id": ["USPTO:C:0"],
+            "patent_number": ["C"],
+            "patent_active": [False],
+            "cpc_ambiguous": [True],
+        }
+    )
+    patents = pl.DataFrame(
+        {"patent_number": ["C"], "abstract": [None], "claims_text": [None], "cpc_codes": [[]]}
+    )
+    reactions = pl.DataFrame({"rxn_id": ["USPTO:C:0"], "reaction_smiles": ["A>>B"]})
+    client = MagicMock()
+    out_path = tmp_path / "llm.parquet"
+    out_df = classify_ambiguous_patents(
+        cpc=cpc, patents=patents, reactions=reactions,
+        cache_path=tmp_path / "cache.jsonl", out_path=out_path,
+        client=client, model="claude-haiku-4-5", max_retries=1,
+    )
+    # Inactive patents are not LLM-classified
+    assert out_df.height == 0
+    assert client.messages.create.call_count == 0

--- a/tests/unit/test_patents_llm_classify.py
+++ b/tests/unit/test_patents_llm_classify.py
@@ -1,13 +1,22 @@
+from datetime import UTC, datetime
+from pathlib import Path
 from unittest.mock import MagicMock
 
+import polars as pl
+
+from aichemy.preprocessing.patents.cache import LLMCacheEntry, append_cache
 from aichemy.preprocessing.patents.llm_classify import (
+    LLM_CLASSIFICATION_SCHEMA,
     LLMClassificationResult,
+    classify_ambiguous_patents,
     classify_patent_llm,
 )
 
 
-def _stub_anthropic_response(*, process: bool, composition: bool, confidence: float, rationale: str):
-    """Build a mock that mimics anthropic.Anthropic().messages.create() returning tool-use."""
+def _stub_anthropic_response(
+    *, process: bool, composition: bool, confidence: float, rationale: str
+):
+    """Build a mock mimicking anthropic.Anthropic().messages.create() tool-use output."""
     block = MagicMock()
     block.type = "tool_use"
     block.name = "report_classification"
@@ -26,7 +35,10 @@ def _stub_anthropic_response(*, process: bool, composition: bool, confidence: fl
 def test_classify_patent_llm_parses_tool_use():
     client = MagicMock()
     client.messages.create.return_value = _stub_anthropic_response(
-        process=True, composition=False, confidence=0.86, rationale="claim 1 method",
+        process=True,
+        composition=False,
+        confidence=0.86,
+        rationale="claim 1 method",
     )
     out = classify_patent_llm(
         client=client,
@@ -53,22 +65,13 @@ def test_classify_patent_llm_returns_none_on_unexpected_stop_reason():
     out = classify_patent_llm(
         client=client,
         patent_number="X",
-        title="t", abstract="a", claims_text="c", reaction_smiles_examples=[],
+        title="t",
+        abstract="a",
+        claims_text="c",
+        reaction_smiles_examples=[],
         model="claude-haiku-4-5",
     )
     assert out is None
-
-
-from datetime import datetime, timezone
-from pathlib import Path
-
-import polars as pl
-
-from aichemy.preprocessing.patents.cache import LLMCacheEntry, append_cache
-from aichemy.preprocessing.patents.llm_classify import (
-    LLM_CLASSIFICATION_SCHEMA,
-    classify_ambiguous_patents,
-)
 
 
 def test_classify_ambiguous_patents_uses_cache_when_present(tmp_path: Path):
@@ -82,7 +85,7 @@ def test_classify_ambiguous_patents_uses_cache_when_present(tmp_path: Path):
             confidence=0.9,
             rationale="cached",
             model="claude-haiku-4-5",
-            ts=datetime.now(tz=timezone.utc).isoformat(),
+            ts=datetime.now(tz=UTC).isoformat(),
         ),
     )
     cpc = pl.DataFrame(
@@ -143,14 +146,22 @@ def test_classify_ambiguous_patents_calls_llm_on_cache_miss(tmp_path: Path):
     reactions = pl.DataFrame({"rxn_id": ["USPTO:B:0"], "reaction_smiles": ["A>>B"]})
     client = MagicMock()
     client.messages.create.return_value = _stub_anthropic_response(
-        process=False, composition=True, confidence=0.7, rationale="composition only",
+        process=False,
+        composition=True,
+        confidence=0.7,
+        rationale="composition only",
     )
     cache_path = tmp_path / "cache.jsonl"
     out_path = tmp_path / "llm.parquet"
     out_df = classify_ambiguous_patents(
-        cpc=cpc, patents=patents, reactions=reactions,
-        cache_path=cache_path, out_path=out_path,
-        client=client, model="claude-haiku-4-5", max_retries=1,
+        cpc=cpc,
+        patents=patents,
+        reactions=reactions,
+        cache_path=cache_path,
+        out_path=out_path,
+        client=client,
+        model="claude-haiku-4-5",
+        max_retries=1,
     )
     assert client.messages.create.call_count == 1
     assert out_df["cache_hit"][0] is False
@@ -176,9 +187,14 @@ def test_classify_ambiguous_patents_skips_inactive(tmp_path: Path):
     client = MagicMock()
     out_path = tmp_path / "llm.parquet"
     out_df = classify_ambiguous_patents(
-        cpc=cpc, patents=patents, reactions=reactions,
-        cache_path=tmp_path / "cache.jsonl", out_path=out_path,
-        client=client, model="claude-haiku-4-5", max_retries=1,
+        cpc=cpc,
+        patents=patents,
+        reactions=reactions,
+        cache_path=tmp_path / "cache.jsonl",
+        out_path=out_path,
+        client=client,
+        model="claude-haiku-4-5",
+        max_retries=1,
     )
     # Inactive patents are not LLM-classified
     assert out_df.height == 0

--- a/uv.lock
+++ b/uv.lock
@@ -64,6 +64,7 @@ dev = [
     { name = "pytest-httpx" },
     { name = "responses" },
     { name = "ruff" },
+    { name = "types-requests" },
 ]
 
 [package.metadata]
@@ -102,6 +103,7 @@ dev = [
     { name = "pytest-httpx", specifier = ">=0.36" },
     { name = "responses", specifier = ">=0.25" },
     { name = "ruff", specifier = ">=0.4" },
+    { name = "types-requests", specifier = ">=2.31" },
 ]
 
 [[package]]
@@ -5756,6 +5758,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.33.0.20260408"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/6a/749dc53a54a3f35842c1f8197b3ca6b54af6d7458a1bfc75f6629b6da666/types_requests-2.33.0.20260408.tar.gz", hash = "sha256:95b9a86376807a216b2fb412b47617b202091c3ea7c078f47cc358d5528ccb7b", size = 23882, upload-time = "2026-04-08T04:34:49.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/b8/78fd6c037de4788c040fdd323b3369804400351b7827473920f6c1d03c10/types_requests-2.33.0.20260408-py3-none-any.whl", hash = "sha256:81f31d5ea4acb39f03be7bc8bed569ba6d5a9c5d97e89f45ac43d819b68ca50f", size = 20739, upload-time = "2026-04-08T04:34:48.325Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Tasks 10–13 of `docs/superpowers/plans/2026-04-25-aichemy-pricing-licensing.md` — the LLM half of the licensing pipeline, layered on top of PR B (#20). Only patents flagged `cpc_ambiguous=True AND patent_active=True` by PR B's CPC stage get an LLM call; the rest pass through.

- **Task 10** — `src/aichemy/preprocessing/patents/cache.py`: JSONL append-only cache with `LLMCacheEntry` dataclass (7 fields) + `load_cache()` / `append_cache()`. Cache key is `patent_number`; later entries with the same key win on read so the file stays human-readable and is replay-friendly.
- **Task 11** — `src/aichemy/preprocessing/patents/llm_classify.py`: `classify_patent_llm(...)` builds a Claude Haiku 4.5 tool-use call against `report_classification`. Returns `LLMClassificationResult(process_covered, composition_covered, confidence, rationale)` or `None` on unexpected `stop_reason`. Tests use a `MagicMock`'d Anthropic client — no real API calls in CI.
- **Task 12** — same module: `classify_ambiguous_patents(...)` filters `cpc` to `cpc_ambiguous & patent_active`, dedups by `patent_number`, hits the cache when present, calls `classify_patent_llm` with exponential-backoff retry otherwise. **Failed calls fall back to `(False, False, 0.0)` and are NOT cached** (so a future retry can succeed without polluting the audit trail). Output parquet matches `LLM_CLASSIFICATION_SCHEMA` so PR D's `augment_licenses` can join on `patent_number`.
- **Task 13** — `src/aichemy/cli.py`: `aichemy patents classify-llm` reads `cpc_classifications.parquet` + `patent_metadata.parquet` + `interim/augmented/reactions_full.parquet`, raises `typer.BadParameter` if `ANTHROPIC_API_KEY` is unset, then calls `classify_ambiguous_patents` with `cache_path` / `model` / `max_retries` from `LicensesConfig`.

## Stacking

This PR stacks on **#20 (PR B)**. Both target `licensing-integration`. Until #20 merges, the diff here will show PR B's 3 commits + this PR's 5; once #20 merges, GitHub auto-trims to just Tasks 10–13.

## Test plan

- [x] `uv run pytest tests/unit/test_patents_llm_cache.py tests/unit/test_patents_llm_classify.py -v` → 8 tests pass (3 cache + 2 single-call + 3 batch)
- [x] `uv run pytest` → 238 pass, only the 2 pre-existing `test_balance_syn_rbl` failures remain (optional `synrbl` extra missing in this env; predates this PR and PR B)
- [x] `uv run aichemy patents --help` lists `fetch`, `classify-cpc`, **`classify-llm`**
- [x] `uv run aichemy patents classify-llm --help` shows `--config`/`--override` (works without `ANTHROPIC_API_KEY` because the env check sits inside the body)
- [x] `uv run ruff check` + `uv run ruff format --check` clean on touched files
- [ ] No real Anthropic API call in tests — `MagicMock` client only

https://claude.ai/code/session_01Udphgmi1UfZ4aQqrHWch5Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01Udphgmi1UfZ4aQqrHWch5Q)_