### PR TITLE
feat(licensing): LLM patent classifier (Tasks 10–13)

### DIFF
--- a/src/aichemy/cli.py
+++ b/src/aichemy/cli.py
@@ -691,9 +691,7 @@ def patents_classify_llm(
     cfg = _load(config, override)
 
     if not os.environ.get("ANTHROPIC_API_KEY"):
-        raise typer.BadParameter(
-            "ANTHROPIC_API_KEY not set; LLM classification cannot proceed."
-        )
+        raise typer.BadParameter("ANTHROPIC_API_KEY not set; LLM classification cannot proceed.")
 
     cpc = pl.read_parquet(licenses_path(cfg, "cpc_classifications.parquet"))
     patents = pl.read_parquet(patents_path(cfg, "patent_metadata.parquet"))

--- a/src/aichemy/cli.py
+++ b/src/aichemy/cli.py
@@ -676,6 +676,48 @@ def patents_classify_cpc(
     )
 
 
+@patents_app.command("classify-llm")
+def patents_classify_llm(
+    config: Path = ConfigOpt,
+    override: list[Path] = OverrideOpt,
+) -> None:
+    """Eagerly classify CPC-ambiguous active patents via Claude; cache results."""
+    import os
+
+    import anthropic
+
+    from aichemy.preprocessing.patents.llm_classify import classify_ambiguous_patents
+
+    cfg = _load(config, override)
+
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        raise typer.BadParameter(
+            "ANTHROPIC_API_KEY not set; LLM classification cannot proceed."
+        )
+
+    cpc = pl.read_parquet(licenses_path(cfg, "cpc_classifications.parquet"))
+    patents = pl.read_parquet(patents_path(cfg, "patent_metadata.parquet"))
+    reactions = read_reactions(interim_path(cfg, "augmented", "reactions_full.parquet"))
+
+    client = anthropic.Anthropic()
+    out_path = licenses_path(cfg, "llm_classifications.parquet")
+    out = classify_ambiguous_patents(
+        cpc=cpc,
+        patents=patents,
+        reactions=reactions,
+        cache_path=cfg.licenses.cache_path,
+        out_path=out_path,
+        client=client,
+        model=cfg.licenses.llm_model,
+        max_retries=cfg.licenses.llm_max_retries,
+    )
+    n_hit = int(out["cache_hit"].sum())
+    typer.echo(
+        f"[patents classify-llm] {out.height} patents classified "
+        f"({n_hit} cache hits, {out.height - n_hit} fresh) → {out_path}"
+    )
+
+
 @app.command("export")
 def export(
     config: Path = ConfigOpt,

--- a/src/aichemy/preprocessing/patents/cache.py
+++ b/src/aichemy/preprocessing/patents/cache.py
@@ -1,0 +1,48 @@
+"""JSONL append-only cache for LLM patent classifications.
+
+One entry per LLM call. Cache key is `patent_number`. PatentsView is
+canonical (abstract/claims for a given patent_number are stable), so the
+cache hit on `patent_number` alone is correct.
+
+Append-only design means the file is human-readable, easy to inspect, and
+each invocation extends the file rather than rewriting it. On read, later
+entries with the same `patent_number` win.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+@dataclass
+class LLMCacheEntry:
+    patent_number: str
+    process_covered: bool
+    composition_covered: bool
+    confidence: float
+    rationale: str
+    model: str
+    ts: str
+
+
+def load_cache(path: Path) -> dict[str, LLMCacheEntry]:
+    """Read cache; later entries with the same patent_number win."""
+    if not path.exists():
+        return {}
+    out: dict[str, LLMCacheEntry] = {}
+    with open(path) as f:
+        for raw_line in f:
+            line = raw_line.strip()
+            if not line:
+                continue
+            data = json.loads(line)
+            out[data["patent_number"]] = LLMCacheEntry(**data)
+    return out
+
+
+def append_cache(path: Path, entry: LLMCacheEntry) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a") as f:
+        f.write(json.dumps(asdict(entry)) + "\n")

--- a/src/aichemy/preprocessing/patents/llm_classify.py
+++ b/src/aichemy/preprocessing/patents/llm_classify.py
@@ -111,9 +111,7 @@ def classify_patent_llm(
         messages=[{"role": "user", "content": user}],
     )
     if msg.stop_reason != "tool_use":
-        log.warning(
-            "Unexpected stop_reason=%s for patent=%s", msg.stop_reason, patent_number
-        )
+        log.warning("Unexpected stop_reason=%s for patent=%s", msg.stop_reason, patent_number)
         return None
     for block in msg.content:
         if getattr(block, "type", None) == "tool_use" and block.name == "report_classification":

--- a/src/aichemy/preprocessing/patents/llm_classify.py
+++ b/src/aichemy/preprocessing/patents/llm_classify.py
@@ -1,0 +1,120 @@
+"""LLM patent classifier using the Anthropic SDK with structured tool-use.
+
+The model is asked to judge two booleans (process_covered, composition_covered)
+plus a self-reported confidence and one-sentence rationale. We use Claude's
+tool-use schema to enforce structure rather than free-form JSON parsing.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+CLASSIFICATION_TOOL = {
+    "name": "report_classification",
+    "description": (
+        "Report whether the given patent's claims cover the synthesis route "
+        "(process) and/or any compound that participates in the reaction "
+        "(composition-of-matter)."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "process_covered": {
+                "type": "boolean",
+                "description": (
+                    "True iff the patent's INDEPENDENT claims cover this specific "
+                    "synthesis route (using these reactants, these conditions, this "
+                    "transformation). Mere disclosure in examples or background does NOT count."
+                ),
+            },
+            "composition_covered": {
+                "type": "boolean",
+                "description": (
+                    "True iff the patent's INDEPENDENT claims cover any participant "
+                    "compound (reactant, intermediate, or product) by composition-of-matter."
+                ),
+            },
+            "confidence": {
+                "type": "number",
+                "minimum": 0.0,
+                "maximum": 1.0,
+                "description": "Self-reported confidence in this classification.",
+            },
+            "rationale": {
+                "type": "string",
+                "description": (
+                    "One sentence citing the specific claim/passage that supports the answer."
+                ),
+            },
+        },
+        "required": ["process_covered", "composition_covered", "confidence", "rationale"],
+    },
+}
+
+
+SYSTEM_PROMPT = (
+    "You are a patent-claims analyst. Given a USPTO patent's title, abstract, and "
+    "independent claims, plus example reaction SMILES extracted from the patent, decide "
+    "whether the patent's CLAIMS (not its background or examples) cover the reaction's "
+    "synthesis route (process) and/or any participant compound by composition-of-matter. "
+    "Be strict: only report True when the claims clearly cover the item. When in doubt, "
+    "report False with a low confidence."
+)
+
+
+@dataclass
+class LLMClassificationResult:
+    process_covered: bool
+    composition_covered: bool
+    confidence: float
+    rationale: str
+
+
+def classify_patent_llm(
+    *,
+    client: Any,
+    patent_number: str,
+    title: str | None,
+    abstract: str | None,
+    claims_text: str | None,
+    reaction_smiles_examples: list[str],
+    model: str,
+) -> LLMClassificationResult | None:
+    """One LLM call, one classification. Returns None on unexpected stop_reason."""
+    examples = "\n".join(reaction_smiles_examples[:5]) or "(none)"
+    user = (
+        f"Patent number: {patent_number}\n\n"
+        f"Title: {title or '(none)'}\n\n"
+        f"Abstract:\n{abstract or '(none)'}\n\n"
+        f"Independent claims:\n{(claims_text or '(none)')[:8000]}\n\n"
+        f"Reaction SMILES extracted from this patent:\n{examples}\n\n"
+        "Use the report_classification tool."
+    )
+    msg = client.messages.create(
+        model=model,
+        max_tokens=512,
+        system=SYSTEM_PROMPT,
+        tools=[CLASSIFICATION_TOOL],
+        tool_choice={"type": "tool", "name": "report_classification"},
+        messages=[{"role": "user", "content": user}],
+    )
+    if msg.stop_reason != "tool_use":
+        log.warning(
+            "Unexpected stop_reason=%s for patent=%s", msg.stop_reason, patent_number
+        )
+        return None
+    for block in msg.content:
+        if getattr(block, "type", None) == "tool_use" and block.name == "report_classification":
+            data = block.input
+            return LLMClassificationResult(
+                process_covered=bool(data["process_covered"]),
+                composition_covered=bool(data["composition_covered"]),
+                confidence=float(data["confidence"]),
+                rationale=str(data["rationale"]),
+            )
+    return None

--- a/src/aichemy/preprocessing/patents/llm_classify.py
+++ b/src/aichemy/preprocessing/patents/llm_classify.py
@@ -8,8 +8,15 @@ tool-use schema to enforce structure rather than free-form JSON parsing.
 from __future__ import annotations
 
 import logging
+import time
 from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
+
+import polars as pl
+
+from aichemy.preprocessing.patents.cache import LLMCacheEntry, append_cache, load_cache
 
 log = logging.getLogger(__name__)
 
@@ -118,3 +125,151 @@ def classify_patent_llm(
                 rationale=str(data["rationale"]),
             )
     return None
+
+
+LLM_CLASSIFICATION_SCHEMA: dict[str, Any] = {
+    "patent_number": pl.Utf8,
+    "process_covered": pl.Boolean,
+    "composition_covered": pl.Boolean,
+    "confidence": pl.Float64,
+    "rationale": pl.Utf8,
+    "model": pl.Utf8,
+    "cache_hit": pl.Boolean,
+}
+
+
+def classify_ambiguous_patents(
+    *,
+    cpc: pl.DataFrame,
+    patents: pl.DataFrame,
+    reactions: pl.DataFrame,
+    cache_path: Path,
+    out_path: Path,
+    client: Any,
+    model: str,
+    max_retries: int = 3,
+    backoff_seconds: float = 1.0,
+) -> pl.DataFrame:
+    """Classify each unique patent flagged ambiguous + active.
+
+    Cache hits don't call the LLM. Misses call once per patent (no retries
+    on the LLM logic itself; transport-level retries on connection errors).
+    Failed calls fall back to (False, False, 0.0) and are NOT cached.
+    """
+    target_patents = (
+        cpc.filter(pl.col("cpc_ambiguous") & pl.col("patent_active"))
+        .select("patent_number")
+        .unique()["patent_number"]
+        .to_list()
+    )
+
+    cache = load_cache(cache_path)
+    rxn_smiles_by_patent = _smiles_index(cpc, reactions)
+    patent_meta = {r["patent_number"]: r for r in patents.iter_rows(named=True)}
+
+    rows: list[dict[str, Any]] = []
+    for pn in target_patents:
+        if pn in cache:
+            entry = cache[pn]
+            rows.append(_to_row(entry, cache_hit=True))
+            continue
+
+        meta = patent_meta.get(pn, {})
+        result = _call_with_retry(
+            client=client,
+            model=model,
+            patent_number=pn,
+            abstract=meta.get("abstract"),
+            claims_text=meta.get("claims_text"),
+            smiles_examples=rxn_smiles_by_patent.get(pn, []),
+            max_retries=max_retries,
+            backoff_seconds=backoff_seconds,
+        )
+        if result is None:
+            rows.append(
+                {
+                    "patent_number": pn,
+                    "process_covered": False,
+                    "composition_covered": False,
+                    "confidence": 0.0,
+                    "rationale": "LLM error — defaulted to no-license",
+                    "model": model,
+                    "cache_hit": False,
+                }
+            )
+            continue
+        entry = LLMCacheEntry(
+            patent_number=pn,
+            process_covered=result.process_covered,
+            composition_covered=result.composition_covered,
+            confidence=result.confidence,
+            rationale=result.rationale,
+            model=model,
+            ts=datetime.now(tz=timezone.utc).isoformat(),
+        )
+        append_cache(cache_path, entry)
+        rows.append(_to_row(entry, cache_hit=False))
+
+    df = pl.DataFrame(rows, schema=LLM_CLASSIFICATION_SCHEMA)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    df.write_parquet(out_path)
+    return df
+
+
+def _smiles_index(cpc: pl.DataFrame, reactions: pl.DataFrame) -> dict[str, list[str]]:
+    if "reaction_smiles" not in reactions.columns:
+        return {}
+    joined = cpc.select("rxn_id", "patent_number").join(
+        reactions.select("rxn_id", "reaction_smiles"), on="rxn_id", how="inner"
+    )
+    out: dict[str, list[str]] = {}
+    for r in joined.iter_rows(named=True):
+        out.setdefault(r["patent_number"], []).append(r["reaction_smiles"])
+    return out
+
+
+def _call_with_retry(
+    *,
+    client: Any,
+    model: str,
+    patent_number: str,
+    abstract: str | None,
+    claims_text: str | None,
+    smiles_examples: list[str],
+    max_retries: int,
+    backoff_seconds: float,
+) -> LLMClassificationResult | None:
+    for attempt in range(max_retries):
+        try:
+            return classify_patent_llm(
+                client=client,
+                patent_number=patent_number,
+                title=None,
+                abstract=abstract,
+                claims_text=claims_text,
+                reaction_smiles_examples=smiles_examples,
+                model=model,
+            )
+        except Exception as exc:
+            log.warning(
+                "LLM call failed (attempt %d/%d) for patent=%s: %s",
+                attempt + 1,
+                max_retries,
+                patent_number,
+                exc,
+            )
+            if attempt < max_retries - 1:
+                time.sleep(backoff_seconds * (2**attempt))
+    return None
+
+
+def _to_row(entry: LLMCacheEntry, *, cache_hit: bool) -> dict[str, Any]:
+    return {
+        "patent_number": entry.patent_number,
+        "process_covered": entry.process_covered,
+        "composition_covered": entry.composition_covered,
+        "confidence": entry.confidence,
+        "rationale": entry.rationale,
+        "model": entry.model,
+        "cache_hit": cache_hit,
+    }

--- a/src/aichemy/preprocessing/patents/llm_classify.py
+++ b/src/aichemy/preprocessing/patents/llm_classify.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -205,7 +205,7 @@ def classify_ambiguous_patents(
             confidence=result.confidence,
             rationale=result.rationale,
             model=model,
-            ts=datetime.now(tz=timezone.utc).isoformat(),
+            ts=datetime.now(tz=UTC).isoformat(),
         )
         append_cache(cache_path, entry)
         rows.append(_to_row(entry, cache_hit=False))

--- a/tests/unit/test_patents_llm_cache.py
+++ b/tests/unit/test_patents_llm_cache.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+from aichemy.preprocessing.patents.cache import (
+    LLMCacheEntry,
+    append_cache,
+    load_cache,
+)
+
+
+def test_load_cache_missing_file_returns_empty(tmp_path: Path):
+    cache_path = tmp_path / "cache.jsonl"
+    assert load_cache(cache_path) == {}
+
+
+def test_append_then_load_roundtrip(tmp_path: Path):
+    cache_path = tmp_path / "cache.jsonl"
+    e = LLMCacheEntry(
+        patent_number="123",
+        process_covered=True,
+        composition_covered=False,
+        confidence=0.9,
+        rationale="claim 1 covers a method",
+        model="claude-haiku-4-5",
+        ts="2026-04-25T00:00:00Z",
+    )
+    append_cache(cache_path, e)
+    loaded = load_cache(cache_path)
+    assert "123" in loaded
+    assert loaded["123"].process_covered is True
+
+
+def test_later_entry_wins_for_duplicate_keys(tmp_path: Path):
+    cache_path = tmp_path / "cache.jsonl"
+    e1 = LLMCacheEntry(
+        patent_number="X",
+        process_covered=False,
+        composition_covered=False,
+        confidence=0.5,
+        rationale="r1",
+        model="m1",
+        ts="2026-01-01T00:00:00Z",
+    )
+    e2 = LLMCacheEntry(
+        patent_number="X",
+        process_covered=True,
+        composition_covered=True,
+        confidence=0.9,
+        rationale="r2",
+        model="m1",
+        ts="2026-04-01T00:00:00Z",
+    )
+    append_cache(cache_path, e1)
+    append_cache(cache_path, e2)
+    loaded = load_cache(cache_path)
+    assert loaded["X"].process_covered is True
+    assert loaded["X"].rationale == "r2"

--- a/tests/unit/test_patents_llm_classify.py
+++ b/tests/unit/test_patents_llm_classify.py
@@ -1,7 +1,14 @@
+from datetime import datetime, timezone
+from pathlib import Path
 from unittest.mock import MagicMock
 
+import polars as pl
+
+from aichemy.preprocessing.patents.cache import LLMCacheEntry, append_cache
 from aichemy.preprocessing.patents.llm_classify import (
+    LLM_CLASSIFICATION_SCHEMA,
     LLMClassificationResult,
+    classify_ambiguous_patents,
     classify_patent_llm,
 )
 
@@ -57,3 +64,117 @@ def test_classify_patent_llm_returns_none_on_unexpected_stop_reason():
         model="claude-haiku-4-5",
     )
     assert out is None
+
+
+def test_classify_ambiguous_patents_uses_cache_when_present(tmp_path: Path):
+    cache_path = tmp_path / "cache.jsonl"
+    append_cache(
+        cache_path,
+        LLMCacheEntry(
+            patent_number="A",
+            process_covered=True,
+            composition_covered=False,
+            confidence=0.9,
+            rationale="cached",
+            model="claude-haiku-4-5",
+            ts=datetime.now(tz=timezone.utc).isoformat(),
+        ),
+    )
+    cpc = pl.DataFrame(
+        {
+            "rxn_id": ["USPTO:A:0"],
+            "patent_number": ["A"],
+            "patent_active": [True],
+            "cpc_ambiguous": [True],
+        }
+    )
+    patents = pl.DataFrame(
+        {
+            "patent_number": ["A"],
+            "abstract": ["x"],
+            "claims_text": ["1. claim"],
+            "cpc_codes": [["A61K"]],
+        }
+    )
+    reactions = pl.DataFrame({"rxn_id": ["USPTO:A:0"], "reaction_smiles": ["A>>B"]})
+    client = MagicMock()
+    out_path = tmp_path / "llm.parquet"
+    out_df = classify_ambiguous_patents(
+        cpc=cpc,
+        patents=patents,
+        reactions=reactions,
+        cache_path=cache_path,
+        out_path=out_path,
+        client=client,
+        model="claude-haiku-4-5",
+        max_retries=1,
+    )
+    assert client.messages.create.call_count == 0  # cache hit
+    assert out_df.height == 1
+    assert out_df["cache_hit"][0] is True
+    assert out_df["process_covered"][0] is True
+    for col, dtype in LLM_CLASSIFICATION_SCHEMA.items():
+        assert col in out_df.columns
+        assert out_df.schema[col] == dtype
+
+
+def test_classify_ambiguous_patents_calls_llm_on_cache_miss(tmp_path: Path):
+    cpc = pl.DataFrame(
+        {
+            "rxn_id": ["USPTO:B:0"],
+            "patent_number": ["B"],
+            "patent_active": [True],
+            "cpc_ambiguous": [True],
+        }
+    )
+    patents = pl.DataFrame(
+        {
+            "patent_number": ["B"],
+            "abstract": ["xyz"],
+            "claims_text": ["1. claim"],
+            "cpc_codes": [["A61K"]],
+        }
+    )
+    reactions = pl.DataFrame({"rxn_id": ["USPTO:B:0"], "reaction_smiles": ["A>>B"]})
+    client = MagicMock()
+    client.messages.create.return_value = _stub_anthropic_response(
+        process=False, composition=True, confidence=0.7, rationale="composition only",
+    )
+    cache_path = tmp_path / "cache.jsonl"
+    out_path = tmp_path / "llm.parquet"
+    out_df = classify_ambiguous_patents(
+        cpc=cpc, patents=patents, reactions=reactions,
+        cache_path=cache_path, out_path=out_path,
+        client=client, model="claude-haiku-4-5", max_retries=1,
+    )
+    assert client.messages.create.call_count == 1
+    assert out_df["cache_hit"][0] is False
+    assert out_df["composition_covered"][0] is True
+    # Cache file now has one entry
+    assert cache_path.exists()
+    assert "B" in cache_path.read_text()
+
+
+def test_classify_ambiguous_patents_skips_inactive(tmp_path: Path):
+    cpc = pl.DataFrame(
+        {
+            "rxn_id": ["USPTO:C:0"],
+            "patent_number": ["C"],
+            "patent_active": [False],
+            "cpc_ambiguous": [True],
+        }
+    )
+    patents = pl.DataFrame(
+        {"patent_number": ["C"], "abstract": [None], "claims_text": [None], "cpc_codes": [[]]}
+    )
+    reactions = pl.DataFrame({"rxn_id": ["USPTO:C:0"], "reaction_smiles": ["A>>B"]})
+    client = MagicMock()
+    out_path = tmp_path / "llm.parquet"
+    out_df = classify_ambiguous_patents(
+        cpc=cpc, patents=patents, reactions=reactions,
+        cache_path=tmp_path / "cache.jsonl", out_path=out_path,
+        client=client, model="claude-haiku-4-5", max_retries=1,
+    )
+    # Inactive patents are not LLM-classified
+    assert out_df.height == 0
+    assert client.messages.create.call_count == 0

--- a/tests/unit/test_patents_llm_classify.py
+++ b/tests/unit/test_patents_llm_classify.py
@@ -1,0 +1,59 @@
+from unittest.mock import MagicMock
+
+from aichemy.preprocessing.patents.llm_classify import (
+    LLMClassificationResult,
+    classify_patent_llm,
+)
+
+
+def _stub_anthropic_response(*, process: bool, composition: bool, confidence: float, rationale: str):
+    """Build a mock that mimics anthropic.Anthropic().messages.create() returning tool-use."""
+    block = MagicMock()
+    block.type = "tool_use"
+    block.name = "report_classification"
+    block.input = {
+        "process_covered": process,
+        "composition_covered": composition,
+        "confidence": confidence,
+        "rationale": rationale,
+    }
+    msg = MagicMock()
+    msg.stop_reason = "tool_use"
+    msg.content = [block]
+    return msg
+
+
+def test_classify_patent_llm_parses_tool_use():
+    client = MagicMock()
+    client.messages.create.return_value = _stub_anthropic_response(
+        process=True, composition=False, confidence=0.86, rationale="claim 1 method",
+    )
+    out = classify_patent_llm(
+        client=client,
+        patent_number="7456123",
+        title="A method",
+        abstract="Method for synthesis…",
+        claims_text="1. A process for…",
+        reaction_smiles_examples=["A>>B"],
+        model="claude-haiku-4-5",
+    )
+    assert isinstance(out, LLMClassificationResult)
+    assert out.process_covered is True
+    assert out.composition_covered is False
+    assert out.confidence == 0.86
+    assert out.rationale.startswith("claim")
+
+
+def test_classify_patent_llm_returns_none_on_unexpected_stop_reason():
+    client = MagicMock()
+    msg = MagicMock()
+    msg.stop_reason = "end_turn"
+    msg.content = []
+    client.messages.create.return_value = msg
+    out = classify_patent_llm(
+        client=client,
+        patent_number="X",
+        title="t", abstract="a", claims_text="c", reaction_smiles_examples=[],
+        model="claude-haiku-4-5",
+    )
+    assert out is None

--- a/tests/unit/test_patents_llm_classify.py
+++ b/tests/unit/test_patents_llm_classify.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -13,7 +13,9 @@ from aichemy.preprocessing.patents.llm_classify import (
 )
 
 
-def _stub_anthropic_response(*, process: bool, composition: bool, confidence: float, rationale: str):
+def _stub_anthropic_response(
+    *, process: bool, composition: bool, confidence: float, rationale: str
+):
     """Build a mock that mimics anthropic.Anthropic().messages.create() returning tool-use."""
     block = MagicMock()
     block.type = "tool_use"
@@ -77,7 +79,7 @@ def test_classify_ambiguous_patents_uses_cache_when_present(tmp_path: Path):
             confidence=0.9,
             rationale="cached",
             model="claude-haiku-4-5",
-            ts=datetime.now(tz=timezone.utc).isoformat(),
+            ts=datetime.now(tz=UTC).isoformat(),
         ),
     )
     cpc = pl.DataFrame(

--- a/tests/unit/test_patents_llm_classify.py
+++ b/tests/unit/test_patents_llm_classify.py
@@ -35,7 +35,10 @@ def _stub_anthropic_response(
 def test_classify_patent_llm_parses_tool_use():
     client = MagicMock()
     client.messages.create.return_value = _stub_anthropic_response(
-        process=True, composition=False, confidence=0.86, rationale="claim 1 method",
+        process=True,
+        composition=False,
+        confidence=0.86,
+        rationale="claim 1 method",
     )
     out = classify_patent_llm(
         client=client,
@@ -62,7 +65,10 @@ def test_classify_patent_llm_returns_none_on_unexpected_stop_reason():
     out = classify_patent_llm(
         client=client,
         patent_number="X",
-        title="t", abstract="a", claims_text="c", reaction_smiles_examples=[],
+        title="t",
+        abstract="a",
+        claims_text="c",
+        reaction_smiles_examples=[],
         model="claude-haiku-4-5",
     )
     assert out is None
@@ -140,14 +146,22 @@ def test_classify_ambiguous_patents_calls_llm_on_cache_miss(tmp_path: Path):
     reactions = pl.DataFrame({"rxn_id": ["USPTO:B:0"], "reaction_smiles": ["A>>B"]})
     client = MagicMock()
     client.messages.create.return_value = _stub_anthropic_response(
-        process=False, composition=True, confidence=0.7, rationale="composition only",
+        process=False,
+        composition=True,
+        confidence=0.7,
+        rationale="composition only",
     )
     cache_path = tmp_path / "cache.jsonl"
     out_path = tmp_path / "llm.parquet"
     out_df = classify_ambiguous_patents(
-        cpc=cpc, patents=patents, reactions=reactions,
-        cache_path=cache_path, out_path=out_path,
-        client=client, model="claude-haiku-4-5", max_retries=1,
+        cpc=cpc,
+        patents=patents,
+        reactions=reactions,
+        cache_path=cache_path,
+        out_path=out_path,
+        client=client,
+        model="claude-haiku-4-5",
+        max_retries=1,
     )
     assert client.messages.create.call_count == 1
     assert out_df["cache_hit"][0] is False
@@ -173,9 +187,14 @@ def test_classify_ambiguous_patents_skips_inactive(tmp_path: Path):
     client = MagicMock()
     out_path = tmp_path / "llm.parquet"
     out_df = classify_ambiguous_patents(
-        cpc=cpc, patents=patents, reactions=reactions,
-        cache_path=tmp_path / "cache.jsonl", out_path=out_path,
-        client=client, model="claude-haiku-4-5", max_retries=1,
+        cpc=cpc,
+        patents=patents,
+        reactions=reactions,
+        cache_path=tmp_path / "cache.jsonl",
+        out_path=out_path,
+        client=client,
+        model="claude-haiku-4-5",
+        max_retries=1,
     )
     # Inactive patents are not LLM-classified
     assert out_df.height == 0


### PR DESCRIPTION
## Summary

Implements Tasks 10–13 of the licensing pipeline (`docs/superpowers/plans/2026-04-25-aichemy-pricing-licensing.md`) on top of the CPC-classifier stage merged in #20. Adds the LLM classifier for CPC-ambiguous active patents with a replayable cache and a Typer CLI subcommand.

- **Task 10** — `src/aichemy/preprocessing/patents/cache.py`: JSONL append-only cache keyed by `patent_number`. `load_cache` is last-write-wins on duplicate keys; missing file → `{}`. (`LLMCacheEntry`, `load_cache`, `append_cache`)
- **Task 11** — `src/aichemy/preprocessing/patents/llm_classify.py` `classify_patent_llm(...)`: one Anthropic `messages.create` call using a `report_classification` tool-use schema (`process_covered`, `composition_covered`, `confidence`, `rationale`). Model defaults to `claude-haiku-4-5` via `LicensesConfig`. Returns `None` on unexpected `stop_reason`.
- **Task 12** — `classify_ambiguous_patents(...)`: eager batch over `cpc.filter(cpc_ambiguous & patent_active).patent_number.unique()`. Cache hits skip the LLM; misses retry with exponential backoff on transport `Exception`s; failures fall back to `(False, False, 0.0, "LLM error — defaulted to no-license")` and are **not** cached. Writes parquet matching `LLM_CLASSIFICATION_SCHEMA`.
- **Task 13** — `aichemy patents classify-llm`: thin CLI wrapper. Raises `typer.BadParameter` if `ANTHROPIC_API_KEY` is unset (before constructing `anthropic.Anthropic()`). Reads `cpc_classifications.parquet`, `patent_metadata.parquet`, `reactions_full.parquet`; writes `data/interim/licenses/llm_classifications.parquet`.

All tests inject `MagicMock()` as the Anthropic client — no real API calls in CI.

## Test plan

- [x] `uv run pytest tests/unit/test_patents_llm_cache.py tests/unit/test_patents_llm_classify.py -v` — 8/8 pass
- [x] `uv run aichemy patents classify-llm --help` — prints help, exits 0
- [x] `uv run ruff check` (touched files) — clean
- [x] `uv run mypy src/aichemy` — strict, 52 source files clean
- [x] `uv run pytest -q` — 238 pass, 1 skipped; 2 pre-existing `synrbl` import failures on `licensing-integration` are unrelated to this change


---
_Generated by [Claude Code](https://claude.ai/code/session_01YW39cuRgQgTN1hZHUroDfZ)_