### PR TITLE
feat(licensing): royalty terms in solver + sweep CLI (Tasks 14–18)

### DIFF
--- a/src/aichemy/cli.py
+++ b/src/aichemy/cli.py
@@ -18,6 +18,7 @@ from aichemy.preprocessing.augment.directionality import DirectionalityMode
 from aichemy.preprocessing.balance import validate as balance_validate_module
 from aichemy.preprocessing.io import (
     interim_path,
+    licenses_path,
     processed_path,
     raw_path,
     read_molecules,
@@ -608,6 +609,41 @@ def augment_directionality(
         augmented = df  # nothing to do without direction annotation
     write_reactions(augmented, output_path)
     typer.echo(f"[augment directionality] wrote {augmented.height} rows.")
+
+
+@augment_app.command("licenses")
+def augment_licenses_cmd(
+    config: Path = ConfigOpt,
+    override: list[Path] = OverrideOpt,
+) -> None:
+    """Merge CPC + LLM license classifications onto reactions."""
+    from aichemy.preprocessing.augment.licenses import augment_licenses
+
+    cfg = _load(config, override)
+    reactions = read_reactions(interim_path(cfg, "augmented", "reactions_full.parquet"))
+    cpc = pl.read_parquet(licenses_path(cfg, "cpc_classifications.parquet"))
+    llm_path = licenses_path(cfg, "llm_classifications.parquet")
+    if llm_path.exists():
+        llm = pl.read_parquet(llm_path)
+    else:
+        llm = pl.DataFrame(
+            schema={
+                "patent_number": pl.Utf8,
+                "process_covered": pl.Boolean,
+                "composition_covered": pl.Boolean,
+            }
+        )
+
+    out = augment_licenses(reactions, cpc, llm)
+    out_path = interim_path(cfg, "augmented", "reactions_licensed.parquet")
+    write_reactions(out, out_path)
+
+    n_proc = int(out["process_covered"].sum())
+    n_comp = int(out["composition_covered"].sum())
+    typer.echo(
+        f"[augment licenses] {out.height} reactions "
+        f"({n_proc} process-covered, {n_comp} composition-covered) → {out_path}"
+    )
 
 
 @app.command("export")

--- a/src/aichemy/preprocessing/augment/licenses.py
+++ b/src/aichemy/preprocessing/augment/licenses.py
@@ -1,0 +1,57 @@
+"""Merge license classifications onto reactions.
+
+Resolution rule:
+- MetaNetX rows (no patent association) → all flags False.
+- USPTO rows: for each (rxn_id, patent_number), if cpc_ambiguous AND a
+  matching LLM row exists, use LLM; otherwise use CPC. Multi-patent
+  reactions OR-aggregate across patents.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+
+def augment_licenses(
+    reactions: pl.DataFrame,
+    cpc: pl.DataFrame,
+    llm: pl.DataFrame,
+) -> pl.DataFrame:
+    """Add patent_active, process_covered, composition_covered columns."""
+    llm_renamed = llm.select(
+        "patent_number",
+        pl.col("process_covered").alias("process_covered_llm"),
+        pl.col("composition_covered").alias("composition_covered_llm"),
+    )
+    resolved = (
+        cpc.join(llm_renamed, on="patent_number", how="left")
+        .with_columns(
+            pl.when(pl.col("cpc_ambiguous") & pl.col("process_covered_llm").is_not_null())
+            .then(pl.col("process_covered_llm"))
+            .otherwise(pl.col("process_covered_cpc"))
+            .alias("process_covered"),
+            pl.when(pl.col("cpc_ambiguous") & pl.col("composition_covered_llm").is_not_null())
+            .then(pl.col("composition_covered_llm"))
+            .otherwise(pl.col("composition_covered_cpc"))
+            .alias("composition_covered"),
+        )
+        .select(
+            "rxn_id",
+            "patent_active",
+            "process_covered",
+            "composition_covered",
+        )
+    )
+
+    aggregated = resolved.group_by("rxn_id").agg(
+        pl.col("patent_active").any().alias("patent_active"),
+        pl.col("process_covered").any().alias("process_covered"),
+        pl.col("composition_covered").any().alias("composition_covered"),
+    )
+
+    out = reactions.join(aggregated, on="rxn_id", how="left").with_columns(
+        pl.col("patent_active").fill_null(False),
+        pl.col("process_covered").fill_null(False),
+        pl.col("composition_covered").fill_null(False),
+    )
+    return out

--- a/src/aichemy/solver/cli.py
+++ b/src/aichemy/solver/cli.py
@@ -40,6 +40,21 @@ _BalanceFilterOpt = typer.Option(
         "strict atom-count) or 'balanced' (looser per-source claim)."
     ),
 )
+_RProcessOpt = typer.Option(
+    "0,0.02,0.04,0.06,0.08",
+    "--r-process",
+    help="Comma-separated decimal fractions for the process royalty axis.",
+)
+_RCompOpt = typer.Option(
+    "0,0.02,0.04,0.06,0.08",
+    "--r-comp",
+    help="Comma-separated decimal fractions for the composition royalty axis.",
+)
+_SweepOutOpt = typer.Option(
+    Path("data/processed/sensitivity"),
+    "--out",
+    help="Output directory.",
+)
 
 
 @solver_app.command("run")
@@ -99,9 +114,7 @@ def _run_sweep(
             sol = build_and_solve(reactions, molecules, cfg)
             cell_dir = out_dir / "runs" / f"r_process_{rp:.4f}_r_comp_{rc:.4f}"
             cell_dir.mkdir(parents=True, exist_ok=True)
-            (cell_dir / "solution.json").write_text(
-                json.dumps(sol.to_dict(), indent=2) + "\n"
-            )
+            (cell_dir / "solution.json").write_text(json.dumps(sol.to_dict(), indent=2) + "\n")
             sold_ids = sorted(s["mol_id"] for s in sol.sold_molecules)
             set_hash = hashlib.sha256(",".join(sold_ids).encode()).hexdigest()[:16]
             rows.append(
@@ -126,21 +139,9 @@ def _run_sweep(
 def sweep(
     config: Path = _ConfigOpt,
     override: list[Path] = _OverrideOpt,
-    r_process: str = typer.Option(
-        "0,0.02,0.04,0.06,0.08",
-        "--r-process",
-        help="Comma-separated decimal fractions for the process royalty axis.",
-    ),
-    r_comp: str = typer.Option(
-        "0,0.02,0.04,0.06,0.08",
-        "--r-comp",
-        help="Comma-separated decimal fractions for the composition royalty axis.",
-    ),
-    out: Path = typer.Option(
-        Path("data/processed/sensitivity"),
-        "--out",
-        help="Output directory.",
-    ),
+    r_process: str = _RProcessOpt,
+    r_comp: str = _RCompOpt,
+    out: Path = _SweepOutOpt,
     backend: str = _BackendOpt,
     verbose: bool = _VerboseOpt,
 ) -> None:
@@ -156,9 +157,7 @@ def sweep(
 
     rp_grid = [float(x) for x in r_process.split(",")]
     rc_grid = [float(x) for x in r_comp.split(",")]
-    typer.echo(
-        f"[solve sweep] {len(rp_grid)}×{len(rc_grid)} = {len(rp_grid) * len(rc_grid)} cells"
-    )
+    typer.echo(f"[solve sweep] {len(rp_grid)}x{len(rc_grid)} = {len(rp_grid) * len(rc_grid)} cells")
     summary = _run_sweep(
         reactions,
         molecules,
@@ -168,6 +167,5 @@ def sweep(
         base_config=base_cfg,
     )
     typer.echo(
-        f"[solve sweep] complete; summary → {out / 'summary.parquet'} "
-        f"({summary.height} rows)"
+        f"[solve sweep] complete; summary → {out / 'summary.parquet'} ({summary.height} rows)"
     )

--- a/src/aichemy/solver/cli.py
+++ b/src/aichemy/solver/cli.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 
+import polars as pl
 import typer
 
 from aichemy.config import load_config
@@ -77,4 +79,95 @@ def solve(
         f"activated={len(solution.activated_reactions)}  "
         f"sold={len(solution.sold_molecules)}  "
         f"→ {solver_cfg.output_path}"
+    )
+
+
+def _run_sweep(
+    reactions: pl.DataFrame,
+    molecules: pl.DataFrame,
+    *,
+    r_process_grid: list[float],
+    r_comp_grid: list[float],
+    out_dir: Path,
+    base_config: SolverConfig,
+) -> pl.DataFrame:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    rows: list[dict] = []
+    for rp in r_process_grid:
+        for rc in r_comp_grid:
+            cfg = base_config.model_copy(update={"r_process": rp, "r_comp": rc})
+            sol = build_and_solve(reactions, molecules, cfg)
+            cell_dir = out_dir / "runs" / f"r_process_{rp:.4f}_r_comp_{rc:.4f}"
+            cell_dir.mkdir(parents=True, exist_ok=True)
+            (cell_dir / "solution.json").write_text(
+                json.dumps(sol.to_dict(), indent=2) + "\n"
+            )
+            sold_ids = sorted(s["mol_id"] for s in sol.sold_molecules)
+            set_hash = hashlib.sha256(",".join(sold_ids).encode()).hexdigest()[:16]
+            rows.append(
+                {
+                    "r_process": rp,
+                    "r_comp": rc,
+                    "objective_value": (
+                        float(sol.objective_value) if sol.status == "Optimal" else None
+                    ),
+                    "n_active_reactions": len(sol.activated_reactions),
+                    "n_sold_products": len(sol.sold_molecules),
+                    "set_hash": set_hash,
+                    "infeasible": sol.status == "Infeasible",
+                }
+            )
+    summary = pl.DataFrame(rows)
+    summary.write_parquet(out_dir / "summary.parquet")
+    return summary
+
+
+@solver_app.command("sweep")
+def sweep(
+    config: Path = _ConfigOpt,
+    override: list[Path] = _OverrideOpt,
+    r_process: str = typer.Option(
+        "0,0.02,0.04,0.06,0.08",
+        "--r-process",
+        help="Comma-separated decimal fractions for the process royalty axis.",
+    ),
+    r_comp: str = typer.Option(
+        "0,0.02,0.04,0.06,0.08",
+        "--r-comp",
+        help="Comma-separated decimal fractions for the composition royalty axis.",
+    ),
+    out: Path = typer.Option(
+        Path("data/processed/sensitivity"),
+        "--out",
+        help="Output directory.",
+    ),
+    backend: str = _BackendOpt,
+    verbose: bool = _VerboseOpt,
+) -> None:
+    """Sweep the (r_process, r_comp) grid; write per-cell solutions + summary parquet."""
+    cfg = load_config(config, override)
+    base_cfg = SolverConfig(
+        backend=backend,  # type: ignore[arg-type]
+        verbose=verbose,
+        output_path=processed_path(cfg, "solution.json"),
+    )
+    reactions = read_reactions(processed_path(cfg, "reactions.parquet"))
+    molecules = read_molecules(processed_path(cfg, "molecules.parquet"))
+
+    rp_grid = [float(x) for x in r_process.split(",")]
+    rc_grid = [float(x) for x in r_comp.split(",")]
+    typer.echo(
+        f"[solve sweep] {len(rp_grid)}×{len(rc_grid)} = {len(rp_grid) * len(rc_grid)} cells"
+    )
+    summary = _run_sweep(
+        reactions,
+        molecules,
+        r_process_grid=rp_grid,
+        r_comp_grid=rc_grid,
+        out_dir=out,
+        base_config=base_cfg,
+    )
+    typer.echo(
+        f"[solve sweep] complete; summary → {out / 'summary.parquet'} "
+        f"({summary.height} rows)"
     )

--- a/src/aichemy/solver/config.py
+++ b/src/aichemy/solver/config.py
@@ -57,5 +57,13 @@ class SolverConfig(BaseModel):
     # Verbosity
     verbose: bool = False
 
+    # Royalty rate on process-covered reaction revenue (decimal, 0.0–1.0).
+    # Default 0.0 means current behavior is unchanged when license data
+    # is absent or rates aren't passed.
+    r_process: float = 0.0
+
+    # Royalty rate on composition-covered product revenue (decimal, 0.0–1.0).
+    r_comp: float = 0.0
+
     # Where to write the JSON summary of the solved problem.
     output_path: Path = Field(default_factory=lambda: Path("data/processed/solution.json"))

--- a/src/aichemy/solver/model.py
+++ b/src/aichemy/solver/model.py
@@ -95,6 +95,18 @@ def build_and_solve(
     if reactions.height == 0:
         return Solution("No reactions after filtering", 0.0, [], [], [])
 
+    # Reaction-level composition_covered → molecule-level: any product of a
+    # composition-covered reaction is itself composition-covered for royalty.
+    if "composition_covered" in reactions.columns:
+        comp_mol_ids: set[str] = set()
+        for row in reactions.iter_rows(named=True):
+            if row.get("composition_covered"):
+                for stoich in row["products"]:
+                    comp_mol_ids.add(stoich["mol_id"])
+        molecules = molecules.with_columns(
+            pl.col("mol_id").is_in(list(comp_mol_ids)).alias("composition_covered")
+        )
+
     # Universe of molecules is every mol_id referenced by a surviving reaction.
     referenced: set[str] = set()
     rxn_meta: list[dict[str, Any]] = []
@@ -113,11 +125,18 @@ def build_and_solve(
                 "yield_rate": yield_rate,
                 "reactants": reactants,
                 "products": products,
+                "process_covered": bool(row.get("process_covered") or False),
             }
         )
 
     # Price lookup: molecule mol_id → (buy_price, sell_price).
     price_lookup = _build_price_lookup(molecules, referenced, config)
+
+    composition_covered: set[str] = set()
+    if "composition_covered" in molecules.columns:
+        for r in molecules.iter_rows(named=True):
+            if r.get("composition_covered"):
+                composition_covered.add(r["mol_id"])
 
     # Build pulp problem.
     prob = pulp.LpProblem("AIchemy_profit", pulp.LpMaximize)
@@ -146,12 +165,25 @@ def build_and_solve(
     }
     w = {mol_id: pulp.LpVariable(f"w_{_safe(mol_id)}", cat=pulp.LpBinary) for mol_id in referenced}
 
-    # Objective: sell revenue − buy cost
-    prob += (
-        pulp.lpSum(price_lookup[m][1] * q_sell[m] for m in referenced)
-        - pulp.lpSum(price_lookup[m][0] * q_buy[m] for m in referenced),
-        "total_profit",
+    # Objective: sell revenue − buy cost − process royalty − composition royalty
+    revenue = pulp.lpSum(price_lookup[m][1] * q_sell[m] for m in referenced)
+    cost = pulp.lpSum(price_lookup[m][0] * q_buy[m] for m in referenced)
+
+    process_royalty = pulp.lpSum(
+        config.r_process
+        * sum(price_lookup[mid][1] for (mid, _) in m["products"])
+        * m["yield_rate"]
+        * f[m["rxn_id"]]
+        for m in rxn_meta
+        if m["process_covered"]
     )
+    composition_royalty = pulp.lpSum(
+        config.r_comp * price_lookup[m][1] * q_sell[m]
+        for m in referenced
+        if m in composition_covered
+    )
+
+    prob += (revenue - cost - process_royalty - composition_royalty, "total_profit")
 
     # Mass balance: for each molecule, supply = consumption.
     for mol_id in referenced:

--- a/tests/unit/test_augment_licenses.py
+++ b/tests/unit/test_augment_licenses.py
@@ -1,0 +1,116 @@
+import polars as pl
+
+from aichemy.preprocessing.augment.licenses import augment_licenses
+
+
+def _reactions(rxns):
+    return pl.DataFrame(
+        {
+            "rxn_id": [r[0] for r in rxns],
+            "source": [r[1] for r in rxns],
+            "balanced": [True] * len(rxns),
+        }
+    )
+
+
+def test_metanetx_rows_get_all_false():
+    reactions = _reactions([("MNXR1", "metanetx")])
+    cpc = pl.DataFrame(
+        schema={
+            "rxn_id": pl.Utf8,
+            "patent_number": pl.Utf8,
+            "patent_active": pl.Boolean,
+            "cpc_ambiguous": pl.Boolean,
+            "process_covered_cpc": pl.Boolean,
+            "composition_covered_cpc": pl.Boolean,
+        }
+    )
+    llm = pl.DataFrame(
+        schema={
+            "patent_number": pl.Utf8,
+            "process_covered": pl.Boolean,
+            "composition_covered": pl.Boolean,
+        }
+    )
+    out = augment_licenses(reactions, cpc, llm)
+    row = out.row(0, named=True)
+    assert row["patent_active"] is False
+    assert row["process_covered"] is False
+    assert row["composition_covered"] is False
+
+
+def test_uspto_unambiguous_uses_cpc():
+    reactions = _reactions([("USPTO:A:0", "uspto")])
+    cpc = pl.DataFrame(
+        {
+            "rxn_id": ["USPTO:A:0"],
+            "patent_number": ["A"],
+            "patent_active": [True],
+            "cpc_ambiguous": [False],
+            "process_covered_cpc": [True],
+            "composition_covered_cpc": [False],
+        }
+    )
+    llm = pl.DataFrame(
+        schema={
+            "patent_number": pl.Utf8,
+            "process_covered": pl.Boolean,
+            "composition_covered": pl.Boolean,
+        }
+    )
+    out = augment_licenses(reactions, cpc, llm)
+    row = out.row(0, named=True)
+    assert row["patent_active"] is True
+    assert row["process_covered"] is True
+    assert row["composition_covered"] is False
+
+
+def test_uspto_ambiguous_uses_llm_when_present():
+    reactions = _reactions([("USPTO:B:0", "uspto")])
+    cpc = pl.DataFrame(
+        {
+            "rxn_id": ["USPTO:B:0"],
+            "patent_number": ["B"],
+            "patent_active": [True],
+            "cpc_ambiguous": [True],
+            "process_covered_cpc": [False],
+            "composition_covered_cpc": [False],
+        }
+    )
+    llm = pl.DataFrame(
+        {
+            "patent_number": ["B"],
+            "process_covered": [False],
+            "composition_covered": [True],
+        }
+    )
+    out = augment_licenses(reactions, cpc, llm)
+    row = out.row(0, named=True)
+    assert row["process_covered"] is False
+    assert row["composition_covered"] is True
+
+
+def test_uspto_ambiguous_falls_back_to_false_when_llm_missing():
+    reactions = _reactions([("USPTO:C:0", "uspto")])
+    cpc = pl.DataFrame(
+        {
+            "rxn_id": ["USPTO:C:0"],
+            "patent_number": ["C"],
+            "patent_active": [True],
+            "cpc_ambiguous": [True],
+            "process_covered_cpc": [False],
+            "composition_covered_cpc": [False],
+        }
+    )
+    llm = pl.DataFrame(
+        schema={
+            "patent_number": pl.Utf8,
+            "process_covered": pl.Boolean,
+            "composition_covered": pl.Boolean,
+        }
+    )
+    out = augment_licenses(reactions, cpc, llm)
+    row = out.row(0, named=True)
+    assert row["patent_active"] is True
+    assert row["process_covered"] is False
+    assert row["composition_covered"] is False

--- a/tests/unit/test_solve_sweep.py
+++ b/tests/unit/test_solve_sweep.py
@@ -1,0 +1,78 @@
+import json
+from pathlib import Path
+
+import polars as pl
+
+from aichemy.solver.cli import _run_sweep
+from aichemy.solver.config import SolverConfig
+
+
+def _fixture():
+    reactions = pl.DataFrame(
+        {
+            "rxn_id": ["RX1"],
+            "yield_rate": [1.0],
+            "reactants": [[{"mol_id": "A", "coefficient": 1.0}]],
+            "products": [[{"mol_id": "C", "coefficient": 1.0}]],
+            "balanced": [True],
+            "patent_active": [True],
+            "process_covered": [True],
+            "composition_covered": [True],
+        }
+    )
+    molecules = pl.DataFrame({"mol_id": ["A", "C"], "price_per_gram": [1.0, 10.0]})
+    return reactions, molecules
+
+
+def test_sweep_writes_summary_with_one_row_per_grid_point(tmp_path: Path):
+    reactions, molecules = _fixture()
+    summary = _run_sweep(
+        reactions,
+        molecules,
+        r_process_grid=[0.0, 0.05],
+        r_comp_grid=[0.0, 0.05],
+        out_dir=tmp_path,
+        base_config=SolverConfig(),
+    )
+    assert summary.height == 4
+    assert set(summary.columns) >= {
+        "r_process",
+        "r_comp",
+        "objective_value",
+        "n_active_reactions",
+        "n_sold_products",
+        "set_hash",
+        "infeasible",
+    }
+    assert (tmp_path / "summary.parquet").exists()
+
+
+def test_sweep_set_hash_changes_when_active_set_changes(tmp_path: Path):
+    """At very high royalty, the optimal solution drops the patent-covered route."""
+    reactions, molecules = _fixture()
+    summary = _run_sweep(
+        reactions,
+        molecules,
+        r_process_grid=[0.0, 0.99],
+        r_comp_grid=[0.0],
+        out_dir=tmp_path,
+        base_config=SolverConfig(),
+    )
+    hashes = summary["set_hash"].to_list()
+    assert hashes[0] != hashes[1]
+
+
+def test_sweep_writes_per_cell_solution_files(tmp_path: Path):
+    reactions, molecules = _fixture()
+    _run_sweep(
+        reactions,
+        molecules,
+        r_process_grid=[0.0],
+        r_comp_grid=[0.0],
+        out_dir=tmp_path,
+        base_config=SolverConfig(),
+    )
+    cells = list((tmp_path / "runs").glob("r_process_*_r_comp_*"))
+    assert len(cells) == 1
+    sol = json.loads((cells[0] / "solution.json").read_text())
+    assert "objective_value" in sol

--- a/tests/unit/test_solver_config_royalty.py
+++ b/tests/unit/test_solver_config_royalty.py
@@ -1,0 +1,13 @@
+from aichemy.solver.config import SolverConfig
+
+
+def test_solver_config_has_royalty_defaults():
+    cfg = SolverConfig()
+    assert cfg.r_process == 0.0
+    assert cfg.r_comp == 0.0
+
+
+def test_solver_config_accepts_custom_royalties():
+    cfg = SolverConfig(r_process=0.05, r_comp=0.03)
+    assert cfg.r_process == 0.05
+    assert cfg.r_comp == 0.03

--- a/tests/unit/test_solver_royalty.py
+++ b/tests/unit/test_solver_royalty.py
@@ -1,0 +1,79 @@
+import polars as pl
+
+from aichemy.solver.config import SolverConfig
+from aichemy.solver.model import build_and_solve
+
+
+def _two_reaction_fixture(*, process_covered: bool, composition_covered: bool):
+    """Single reaction A + B → C; price A=$1/g, B=$1/g, C=$10/g; yield 1.0."""
+    reactions = pl.DataFrame(
+        {
+            "rxn_id": ["RX1"],
+            "yield_rate": [1.0],
+            "reactants": [
+                [
+                    {"mol_id": "A", "coefficient": 1.0},
+                    {"mol_id": "B", "coefficient": 1.0},
+                ]
+            ],
+            "products": [[{"mol_id": "C", "coefficient": 1.0}]],
+            "balanced": [True],
+            "patent_active": [process_covered or composition_covered],
+            "process_covered": [process_covered],
+            "composition_covered": [composition_covered],
+        }
+    )
+    molecules = pl.DataFrame(
+        {
+            "mol_id": ["A", "B", "C"],
+            "price_per_gram": [1.0, 1.0, 10.0],
+        }
+    )
+    return reactions, molecules
+
+
+def test_zero_royalty_matches_baseline_objective():
+    reactions, molecules = _two_reaction_fixture(
+        process_covered=True, composition_covered=True
+    )
+    sol_zero = build_and_solve(
+        reactions, molecules, SolverConfig(r_process=0.0, r_comp=0.0)
+    )
+    reactions_legacy = reactions.drop(
+        ["patent_active", "process_covered", "composition_covered"]
+    )
+    sol_legacy = build_and_solve(reactions_legacy, molecules, SolverConfig())
+    assert abs(sol_zero.objective_value - sol_legacy.objective_value) < 1e-3
+
+
+def test_process_royalty_reduces_objective_by_expected_amount():
+    reactions, molecules = _two_reaction_fixture(
+        process_covered=True, composition_covered=False
+    )
+    cfg_no = SolverConfig(r_process=0.0, r_comp=0.0)
+    cfg_p = SolverConfig(r_process=0.5, r_comp=0.0)
+    sol_no = build_and_solve(reactions, molecules, cfg_no)
+    sol_p = build_and_solve(reactions, molecules, cfg_p)
+    expected_delta = 0.5 * 10.0 * 1.0 * sol_no.activated_reactions[0]["flow"]
+    assert abs((sol_no.objective_value - sol_p.objective_value) - expected_delta) < 1e-2
+
+
+def test_composition_royalty_reduces_objective_by_expected_amount():
+    reactions, molecules = _two_reaction_fixture(
+        process_covered=False, composition_covered=True
+    )
+    sol_no = build_and_solve(
+        reactions, molecules, SolverConfig(r_process=0.0, r_comp=0.0)
+    )
+    sol_c = build_and_solve(
+        reactions, molecules, SolverConfig(r_process=0.0, r_comp=0.5)
+    )
+    # Royalty paid = r_comp · price · qty_sold(C) where qty_sold is the
+    # productive (post-royalty) quantity. The zero-royalty case tolerates
+    # zero-margin buy/resell arbitrage on C (buy_price == sell_price), so
+    # sol_no.sold_qty(C) over-counts by the arbitrage volume; the royalty
+    # case eliminates it. Both solutions reach the same objective minus
+    # exactly r_comp · price · qty_sold_in_sol_c[C].
+    sold_qty = next(s for s in sol_c.sold_molecules if s["mol_id"] == "C")["quantity"]
+    expected_delta = 0.5 * 10.0 * sold_qty
+    assert abs((sol_no.objective_value - sol_c.objective_value) - expected_delta) < 1e-2

--- a/tests/unit/test_solver_royalty.py
+++ b/tests/unit/test_solver_royalty.py
@@ -33,23 +33,15 @@ def _two_reaction_fixture(*, process_covered: bool, composition_covered: bool):
 
 
 def test_zero_royalty_matches_baseline_objective():
-    reactions, molecules = _two_reaction_fixture(
-        process_covered=True, composition_covered=True
-    )
-    sol_zero = build_and_solve(
-        reactions, molecules, SolverConfig(r_process=0.0, r_comp=0.0)
-    )
-    reactions_legacy = reactions.drop(
-        ["patent_active", "process_covered", "composition_covered"]
-    )
+    reactions, molecules = _two_reaction_fixture(process_covered=True, composition_covered=True)
+    sol_zero = build_and_solve(reactions, molecules, SolverConfig(r_process=0.0, r_comp=0.0))
+    reactions_legacy = reactions.drop(["patent_active", "process_covered", "composition_covered"])
     sol_legacy = build_and_solve(reactions_legacy, molecules, SolverConfig())
     assert abs(sol_zero.objective_value - sol_legacy.objective_value) < 1e-3
 
 
 def test_process_royalty_reduces_objective_by_expected_amount():
-    reactions, molecules = _two_reaction_fixture(
-        process_covered=True, composition_covered=False
-    )
+    reactions, molecules = _two_reaction_fixture(process_covered=True, composition_covered=False)
     cfg_no = SolverConfig(r_process=0.0, r_comp=0.0)
     cfg_p = SolverConfig(r_process=0.5, r_comp=0.0)
     sol_no = build_and_solve(reactions, molecules, cfg_no)
@@ -59,15 +51,9 @@ def test_process_royalty_reduces_objective_by_expected_amount():
 
 
 def test_composition_royalty_reduces_objective_by_expected_amount():
-    reactions, molecules = _two_reaction_fixture(
-        process_covered=False, composition_covered=True
-    )
-    sol_no = build_and_solve(
-        reactions, molecules, SolverConfig(r_process=0.0, r_comp=0.0)
-    )
-    sol_c = build_and_solve(
-        reactions, molecules, SolverConfig(r_process=0.0, r_comp=0.5)
-    )
+    reactions, molecules = _two_reaction_fixture(process_covered=False, composition_covered=True)
+    sol_no = build_and_solve(reactions, molecules, SolverConfig(r_process=0.0, r_comp=0.0))
+    sol_c = build_and_solve(reactions, molecules, SolverConfig(r_process=0.0, r_comp=0.5))
     # Royalty paid = r_comp · price · qty_sold(C) where qty_sold is the
     # productive (post-royalty) quantity. The zero-royalty case tolerates
     # zero-margin buy/resell arbitrage on C (buy_price == sell_price), so


### PR DESCRIPTION
## Summary

Implements Tasks 14–18 from `docs/superpowers/plans/2026-04-25-aichemy-pricing-licensing.md`, wiring patent licensing into the MILP as a royalty cost on the objective and adding a sensitivity-sweep CLI subcommand.

- **Task 14** — `augment_licenses(reactions, cpc, llm)` in `src/aichemy/preprocessing/augment/licenses.py`. LLM verdict wins on `cpc_ambiguous AND LLM-row-present`; CPC otherwise; multi-patent reactions OR-aggregate; MetaNetX rows fall through with all flags `False`.
- **Task 15** — `aichemy augment licenses` subcommand on the existing `augment_app` (with empty-but-typed LLM frame fallback when `llm_classifications.parquet` is absent).
- **Task 16** — `r_process: float = 0.0` and `r_comp: float = 0.0` on `SolverConfig`.
- **Task 17** — `build_and_solve()` now subtracts `r_process · Σ_{r ∈ process_covered} (price_sell[product] · η_r · f_r)` and `r_comp · Σ_{m ∈ composition_covered} (price_sell[m] · q_sell[m])` from the objective. Reaction-level `composition_covered` is propagated to molecules via product membership. **No new variables, no new constraints**, both terms linear in existing decision variables.
- **Task 18** — `aichemy solve sweep` loops `build_and_solve()` over a 2-D `(r_process, r_comp)` grid, writes per-cell `solution.json` and a top-level `summary.parquet` keyed by a 16-char SHA-256 `set_hash` of sorted sold `mol_id`s for downstream "decision invariance" analysis.

### Backward compatibility

The existing `tests/unit/test_solver.py` does not set license columns. With the columns absent, `process_covered` defaults to `False` per row, the molecule-level `composition_covered` set stays empty, both royalty `lpSum`s collapse to `0`, and the objective is identical to before — the file passes unchanged on this branch.

### Test note (composition royalty)

The plan's `test_composition_royalty_reduces_objective_by_expected_amount` derived `expected_delta` from `sol_no.sold_qty(C)`. At `r_comp=0`, the model permits zero-margin buy/resell arbitrage on `C` (the price lookup uses the same value for buy and sell), so `sol_no` non-deterministically picks an arbitrage-padded `sold_qty`. The royalty case eliminates the arbitrage, so the *productive* sold qty (and hence the actual royalty paid) lives in `sol_c`. The test now references `sol_c.sold_qty(C)` and a comment documents the reasoning. Same property is being verified.

## Test plan

- [x] `uv run pytest tests/unit/test_augment_licenses.py -v` — 4/4 pass
- [x] `uv run aichemy augment licenses --help` — registers
- [x] `uv run pytest tests/unit/test_solver_config_royalty.py -v` — 2/2 pass
- [x] `uv run pytest tests/unit/test_solver_royalty.py -v` — 3/3 pass (incl. zero-royalty equivalence)
- [x] `uv run pytest tests/unit/test_solver.py -v` — 9/9 pass (unchanged)
- [x] `uv run pytest tests/unit/test_solve_sweep.py -v` — 3/3 pass
- [x] `uv run aichemy solve sweep --help` — registers
- [x] `uv run pytest tests/unit/ --ignore=tests/unit/test_balance_syn_rbl.py` — 203/203 pass (the two `test_balance_syn_rbl.py` failures are a pre-existing missing-`synrbl`-package issue on this environment, not from this branch)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01PP5cWybxYFFKzypBpTCC82)_