### PR TITLE
feat(licensing): augment_licenses + MILP royalty terms + solve sweep (Tasks 14–18)

### DIFF
--- a/src/aichemy/cli.py
+++ b/src/aichemy/cli.py
@@ -8,6 +8,7 @@ import typer
 from aichemy.config import PreprocessingConfig, load_config
 from aichemy.preprocessing import export as export_module
 from aichemy.preprocessing.augment import directionality as directionality_module
+from aichemy.preprocessing.augment import licenses as licenses_module
 from aichemy.preprocessing.augment import prices as prices_module
 from aichemy.preprocessing.augment import (
     prices_scrapers as _prices_scrapers,  # noqa: F401 — side effect: registers scrapers
@@ -612,6 +613,61 @@ def augment_directionality(
         augmented = df  # nothing to do without direction annotation
     write_reactions(augmented, output_path)
     typer.echo(f"[augment directionality] wrote {augmented.height} rows.")
+
+
+@augment_app.command("licenses")
+def augment_licenses_cmd(
+    config: Path = ConfigOpt,
+    override: list[Path] = OverrideOpt,
+) -> None:
+    """Merge CPC + LLM license classifications onto reactions."""
+    cfg = _load(config, override)
+    input_path = interim_path(cfg, "augmented", "reactions_full.parquet")
+    output_path = interim_path(cfg, "augmented", "reactions_licensed.parquet")
+
+    if not input_path.exists():
+        write_empty_reactions(output_path)
+        typer.echo(f"[augment licenses] upstream {input_path} missing; wrote empty parquet.")
+        return
+
+    reactions = read_reactions(input_path)
+    cpc_path = licenses_path(cfg, "cpc_classifications.parquet")
+    llm_path = licenses_path(cfg, "llm_classifications.parquet")
+
+    if cpc_path.exists():
+        cpc = pl.read_parquet(cpc_path)
+    else:
+        cpc = pl.DataFrame(
+            schema={
+                "rxn_id": pl.Utf8,
+                "patent_number": pl.Utf8,
+                "patent_active": pl.Boolean,
+                "cpc_ambiguous": pl.Boolean,
+                "process_covered_cpc": pl.Boolean,
+                "composition_covered_cpc": pl.Boolean,
+            }
+        )
+
+    if llm_path.exists():
+        llm = pl.read_parquet(llm_path)
+    else:
+        llm = pl.DataFrame(
+            schema={
+                "patent_number": pl.Utf8,
+                "process_covered": pl.Boolean,
+                "composition_covered": pl.Boolean,
+            }
+        )
+
+    out = licenses_module.augment_licenses(reactions, cpc, llm)
+    write_reactions(out, output_path)
+
+    n_proc = int(out["process_covered"].sum())
+    n_comp = int(out["composition_covered"].sum())
+    typer.echo(
+        f"[augment licenses] {out.height} reactions "
+        f"({n_proc} process-covered, {n_comp} composition-covered) → {output_path}"
+    )
 
 
 @patents_app.command("fetch")

--- a/src/aichemy/preprocessing/augment/licenses.py
+++ b/src/aichemy/preprocessing/augment/licenses.py
@@ -1,0 +1,56 @@
+"""Merge license classifications onto reactions (Task 14).
+
+Resolution rule (per `(rxn_id, patent_number)` pair):
+- If `cpc_ambiguous` AND a matching LLM row exists → use LLM verdict.
+- Else → use the CPC verdict.
+
+Then OR-aggregate per `rxn_id` (a reaction with multiple patents — not
+currently produced by upstream stages, but supported by this schema — gets
+the OR across patents). Finally left-join onto the full reactions DataFrame
+so MetaNetX rows (no patent association) end up with all flags False via
+`fill_null(False)`.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+
+def augment_licenses(
+    reactions: pl.DataFrame,
+    cpc: pl.DataFrame,
+    llm: pl.DataFrame,
+) -> pl.DataFrame:
+    """Add patent_active, process_covered, composition_covered columns to reactions."""
+    llm_renamed = llm.select(
+        "patent_number",
+        pl.col("process_covered").alias("process_covered_llm"),
+        pl.col("composition_covered").alias("composition_covered_llm"),
+    )
+
+    resolved = (
+        cpc.join(llm_renamed, on="patent_number", how="left")
+        .with_columns(
+            pl.when(pl.col("cpc_ambiguous") & pl.col("process_covered_llm").is_not_null())
+            .then(pl.col("process_covered_llm"))
+            .otherwise(pl.col("process_covered_cpc"))
+            .alias("process_covered"),
+            pl.when(pl.col("cpc_ambiguous") & pl.col("composition_covered_llm").is_not_null())
+            .then(pl.col("composition_covered_llm"))
+            .otherwise(pl.col("composition_covered_cpc"))
+            .alias("composition_covered"),
+        )
+        .select("rxn_id", "patent_active", "process_covered", "composition_covered")
+    )
+
+    aggregated = resolved.group_by("rxn_id").agg(
+        pl.col("patent_active").any().alias("patent_active"),
+        pl.col("process_covered").any().alias("process_covered"),
+        pl.col("composition_covered").any().alias("composition_covered"),
+    )
+
+    return reactions.join(aggregated, on="rxn_id", how="left").with_columns(
+        pl.col("patent_active").fill_null(False),
+        pl.col("process_covered").fill_null(False),
+        pl.col("composition_covered").fill_null(False),
+    )

--- a/src/aichemy/solver/cli.py
+++ b/src/aichemy/solver/cli.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 
+import polars as pl
 import typer
 
 from aichemy.config import load_config
@@ -37,6 +39,21 @@ _BalanceFilterOpt = typer.Option(
         "Which boolean column gates reactions: 'rdkit_balanced' (default, "
         "strict atom-count) or 'balanced' (looser per-source claim)."
     ),
+)
+_RProcessOpt = typer.Option(
+    "0,0.02,0.04,0.06,0.08",
+    "--r-process",
+    help="Comma-separated decimal fractions for the process royalty axis.",
+)
+_RCompOpt = typer.Option(
+    "0,0.02,0.04,0.06,0.08",
+    "--r-comp",
+    help="Comma-separated decimal fractions for the composition royalty axis.",
+)
+_SweepOutOpt = typer.Option(
+    Path("data/processed/sensitivity"),
+    "--out",
+    help="Output directory.",
 )
 
 
@@ -77,4 +94,87 @@ def solve(
         f"activated={len(solution.activated_reactions)}  "
         f"sold={len(solution.sold_molecules)}  "
         f"→ {solver_cfg.output_path}"
+    )
+
+
+def _run_sweep(
+    reactions: pl.DataFrame,
+    molecules: pl.DataFrame,
+    *,
+    r_process_grid: list[float],
+    r_comp_grid: list[float],
+    out_dir: Path,
+    base_config: SolverConfig,
+) -> pl.DataFrame:
+    """Loop the (r_process, r_comp) grid; write per-cell solutions + summary parquet.
+
+    Per-cell output: ``out_dir/runs/r_process_<rp:.4f>_r_comp_<rc:.4f>/solution.json``.
+    Summary: ``out_dir/summary.parquet`` with one row per grid point and a
+    ``set_hash`` column for "decision invariance" plotting.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    rows: list[dict] = []
+    for rp in r_process_grid:
+        for rc in r_comp_grid:
+            cfg = base_config.model_copy(update={"r_process": rp, "r_comp": rc})
+            sol = build_and_solve(reactions, molecules, cfg)
+            cell_dir = out_dir / "runs" / f"r_process_{rp:.4f}_r_comp_{rc:.4f}"
+            cell_dir.mkdir(parents=True, exist_ok=True)
+            (cell_dir / "solution.json").write_text(json.dumps(sol.to_dict(), indent=2) + "\n")
+            sold_ids = sorted(s["mol_id"] for s in sol.sold_molecules)
+            set_hash = hashlib.sha256(",".join(sold_ids).encode()).hexdigest()[:16]
+            rows.append(
+                {
+                    "r_process": rp,
+                    "r_comp": rc,
+                    "objective_value": (
+                        float(sol.objective_value) if sol.status == "Optimal" else None
+                    ),
+                    "n_active_reactions": len(sol.activated_reactions),
+                    "n_sold_products": len(sol.sold_molecules),
+                    "set_hash": set_hash,
+                    "infeasible": sol.status == "Infeasible",
+                }
+            )
+    summary = pl.DataFrame(rows)
+    summary.write_parquet(out_dir / "summary.parquet")
+    return summary
+
+
+@solver_app.command("sweep")
+def sweep(
+    config: Path = _ConfigOpt,
+    override: list[Path] = _OverrideOpt,
+    r_process: str = _RProcessOpt,
+    r_comp: str = _RCompOpt,
+    out: Path = _SweepOutOpt,
+    backend: str = _BackendOpt,
+    verbose: bool = _VerboseOpt,
+    balance_filter: str = _BalanceFilterOpt,
+) -> None:
+    """Sweep the (r_process, r_comp) grid; write per-cell solutions + summary parquet."""
+    cfg = load_config(config, override)
+    base_cfg = SolverConfig(
+        backend=backend,  # type: ignore[arg-type]
+        verbose=verbose,
+        output_path=processed_path(cfg, "solution.json"),
+        balance_filter=balance_filter,  # type: ignore[arg-type]
+    )
+
+    reactions = read_reactions(processed_path(cfg, "reactions.parquet"))
+    molecules = read_molecules(processed_path(cfg, "molecules.parquet"))
+
+    rp_grid = [float(x) for x in r_process.split(",")]
+    rc_grid = [float(x) for x in r_comp.split(",")]
+    typer.echo(f"[solve sweep] {len(rp_grid)}x{len(rc_grid)} = {len(rp_grid) * len(rc_grid)} cells")
+    summary = _run_sweep(
+        reactions,
+        molecules,
+        r_process_grid=rp_grid,
+        r_comp_grid=rc_grid,
+        out_dir=out,
+        base_config=base_cfg,
+    )
+    typer.echo(
+        f"[solve sweep] complete; summary → {out / 'summary.parquet'} ({summary.height} rows)"
     )

--- a/src/aichemy/solver/config.py
+++ b/src/aichemy/solver/config.py
@@ -57,5 +57,13 @@ class SolverConfig(BaseModel):
     # Verbosity
     verbose: bool = False
 
+    # Royalty rate on process-covered reaction revenue (decimal fraction, [0, 1]).
+    # Default 0.0 preserves legacy behavior when license data is absent or
+    # the sweep CLI hasn't been invoked.
+    r_process: float = 0.0
+
+    # Royalty rate on composition-covered product revenue (decimal fraction, [0, 1]).
+    r_comp: float = 0.0
+
     # Where to write the JSON summary of the solved problem.
     output_path: Path = Field(default_factory=lambda: Path("data/processed/solution.json"))

--- a/src/aichemy/solver/model.py
+++ b/src/aichemy/solver/model.py
@@ -95,6 +95,19 @@ def build_and_solve(
     if reactions.height == 0:
         return Solution("No reactions after filtering", 0.0, [], [], [])
 
+    # Reaction-level composition_covered → molecule-level: any product of a
+    # composition-covered reaction is itself composition-covered for royalty.
+    # Defensive: only runs when the column is present (license data attached).
+    if "composition_covered" in reactions.columns:
+        comp_mol_ids: set[str] = set()
+        for row in reactions.iter_rows(named=True):
+            if row.get("composition_covered"):
+                for stoich in row["products"]:
+                    comp_mol_ids.add(stoich["mol_id"])
+        molecules = molecules.with_columns(
+            pl.col("mol_id").is_in(list(comp_mol_ids)).alias("composition_covered")
+        )
+
     # Universe of molecules is every mol_id referenced by a surviving reaction.
     referenced: set[str] = set()
     rxn_meta: list[dict[str, Any]] = []
@@ -113,8 +126,16 @@ def build_and_solve(
                 "yield_rate": yield_rate,
                 "reactants": reactants,
                 "products": products,
+                "process_covered": bool(row.get("process_covered") or False),
             }
         )
+
+    # Composition-covered molecule set (drives the composition royalty term).
+    composition_covered: set[str] = set()
+    if "composition_covered" in molecules.columns:
+        for r in molecules.iter_rows(named=True):
+            if r.get("composition_covered"):
+                composition_covered.add(r["mol_id"])
 
     # Price lookup: molecule mol_id → (buy_price, sell_price).
     price_lookup = _build_price_lookup(molecules, referenced, config)
@@ -146,12 +167,25 @@ def build_and_solve(
     }
     w = {mol_id: pulp.LpVariable(f"w_{_safe(mol_id)}", cat=pulp.LpBinary) for mol_id in referenced}
 
-    # Objective: sell revenue − buy cost
-    prob += (
-        pulp.lpSum(price_lookup[m][1] * q_sell[m] for m in referenced)
-        - pulp.lpSum(price_lookup[m][0] * q_buy[m] for m in referenced),
-        "total_profit",
+    # Objective: sell revenue − buy cost − process royalty − composition royalty.
+    # Royalty terms are zero whenever (a) license data isn't attached to the
+    # input reactions/molecules, or (b) config.r_process / config.r_comp are 0.
+    revenue = pulp.lpSum(price_lookup[m][1] * q_sell[m] for m in referenced)
+    cost = pulp.lpSum(price_lookup[m][0] * q_buy[m] for m in referenced)
+    process_royalty = pulp.lpSum(
+        config.r_process
+        * sum(price_lookup[mid][1] for (mid, _) in m["products"])
+        * m["yield_rate"]
+        * f[m["rxn_id"]]
+        for m in rxn_meta
+        if m["process_covered"]
     )
+    composition_royalty = pulp.lpSum(
+        config.r_comp * price_lookup[m][1] * q_sell[m]
+        for m in referenced
+        if m in composition_covered
+    )
+    prob += (revenue - cost - process_royalty - composition_royalty, "total_profit")
 
     # Mass balance: for each molecule, supply = consumption.
     for mol_id in referenced:

--- a/tests/unit/test_augment_licenses.py
+++ b/tests/unit/test_augment_licenses.py
@@ -1,0 +1,112 @@
+"""Resolution rule for the augment_licenses merge step (Task 14)."""
+
+from __future__ import annotations
+
+import polars as pl
+
+from aichemy.preprocessing.augment.licenses import augment_licenses
+
+
+def _reactions(rxns):
+    return pl.DataFrame(
+        {
+            "rxn_id": [r[0] for r in rxns],
+            "source": [r[1] for r in rxns],
+            "balanced": [True] * len(rxns),
+        }
+    )
+
+
+def _empty_cpc():
+    return pl.DataFrame(
+        schema={
+            "rxn_id": pl.Utf8,
+            "patent_number": pl.Utf8,
+            "patent_active": pl.Boolean,
+            "cpc_ambiguous": pl.Boolean,
+            "process_covered_cpc": pl.Boolean,
+            "composition_covered_cpc": pl.Boolean,
+        }
+    )
+
+
+def _empty_llm():
+    return pl.DataFrame(
+        schema={
+            "patent_number": pl.Utf8,
+            "process_covered": pl.Boolean,
+            "composition_covered": pl.Boolean,
+        }
+    )
+
+
+def test_metanetx_rows_get_all_false():
+    reactions = _reactions([("MNXR1", "metanetx")])
+    out = augment_licenses(reactions, _empty_cpc(), _empty_llm())
+    row = out.row(0, named=True)
+    assert row["patent_active"] is False
+    assert row["process_covered"] is False
+    assert row["composition_covered"] is False
+
+
+def test_uspto_unambiguous_uses_cpc():
+    reactions = _reactions([("USPTO:A:0", "uspto")])
+    cpc = pl.DataFrame(
+        {
+            "rxn_id": ["USPTO:A:0"],
+            "patent_number": ["A"],
+            "patent_active": [True],
+            "cpc_ambiguous": [False],
+            "process_covered_cpc": [True],
+            "composition_covered_cpc": [False],
+        }
+    )
+    out = augment_licenses(reactions, cpc, _empty_llm())
+    row = out.row(0, named=True)
+    assert row["patent_active"] is True
+    assert row["process_covered"] is True
+    assert row["composition_covered"] is False
+
+
+def test_uspto_ambiguous_uses_llm_when_present():
+    reactions = _reactions([("USPTO:B:0", "uspto")])
+    cpc = pl.DataFrame(
+        {
+            "rxn_id": ["USPTO:B:0"],
+            "patent_number": ["B"],
+            "patent_active": [True],
+            "cpc_ambiguous": [True],
+            "process_covered_cpc": [False],
+            "composition_covered_cpc": [False],
+        }
+    )
+    llm = pl.DataFrame(
+        {
+            "patent_number": ["B"],
+            "process_covered": [False],
+            "composition_covered": [True],
+        }
+    )
+    out = augment_licenses(reactions, cpc, llm)
+    row = out.row(0, named=True)
+    assert row["process_covered"] is False
+    assert row["composition_covered"] is True
+
+
+def test_uspto_ambiguous_falls_back_to_false_when_llm_missing():
+    reactions = _reactions([("USPTO:C:0", "uspto")])
+    cpc = pl.DataFrame(
+        {
+            "rxn_id": ["USPTO:C:0"],
+            "patent_number": ["C"],
+            "patent_active": [True],
+            "cpc_ambiguous": [True],
+            "process_covered_cpc": [False],
+            "composition_covered_cpc": [False],
+        }
+    )
+    out = augment_licenses(reactions, cpc, _empty_llm())
+    row = out.row(0, named=True)
+    assert row["patent_active"] is True
+    assert row["process_covered"] is False
+    assert row["composition_covered"] is False

--- a/tests/unit/test_solve_sweep.py
+++ b/tests/unit/test_solve_sweep.py
@@ -1,0 +1,83 @@
+"""Tests for the `solve sweep` CLI helper (Task 18)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import polars as pl
+
+from aichemy.solver.cli import _run_sweep
+from aichemy.solver.config import SolverConfig
+
+
+def _fixture():
+    reactions = pl.DataFrame(
+        {
+            "rxn_id": ["RX1"],
+            "yield_rate": [1.0],
+            "reactants": [[{"mol_id": "A", "coefficient": 1.0}]],
+            "products": [[{"mol_id": "C", "coefficient": 1.0}]],
+            "rdkit_balanced": [True],
+            "balanced": [True],
+            "patent_active": [True],
+            "process_covered": [True],
+            "composition_covered": [True],
+        }
+    )
+    molecules = pl.DataFrame({"mol_id": ["A", "C"], "price_per_gram": [1.0, 10.0]})
+    return reactions, molecules
+
+
+def test_sweep_writes_summary_with_one_row_per_grid_point(tmp_path: Path):
+    reactions, molecules = _fixture()
+    summary = _run_sweep(
+        reactions,
+        molecules,
+        r_process_grid=[0.0, 0.05],
+        r_comp_grid=[0.0, 0.05],
+        out_dir=tmp_path,
+        base_config=SolverConfig(),
+    )
+    assert summary.height == 4
+    assert set(summary.columns) >= {
+        "r_process",
+        "r_comp",
+        "objective_value",
+        "n_active_reactions",
+        "n_sold_products",
+        "set_hash",
+        "infeasible",
+    }
+    assert (tmp_path / "summary.parquet").exists()
+
+
+def test_sweep_set_hash_changes_when_active_set_changes(tmp_path: Path):
+    """Very high royalty turns the patent-covered route off → different set_hash."""
+    reactions, molecules = _fixture()
+    summary = _run_sweep(
+        reactions,
+        molecules,
+        r_process_grid=[0.0, 0.99],
+        r_comp_grid=[0.0],
+        out_dir=tmp_path,
+        base_config=SolverConfig(),
+    )
+    hashes = summary["set_hash"].to_list()
+    assert hashes[0] != hashes[1]
+
+
+def test_sweep_writes_per_cell_solution_files(tmp_path: Path):
+    reactions, molecules = _fixture()
+    _run_sweep(
+        reactions,
+        molecules,
+        r_process_grid=[0.0],
+        r_comp_grid=[0.0],
+        out_dir=tmp_path,
+        base_config=SolverConfig(),
+    )
+    cells = list((tmp_path / "runs").glob("r_process_*_r_comp_*"))
+    assert len(cells) == 1
+    sol = json.loads((cells[0] / "solution.json").read_text())
+    assert "objective_value" in sol

--- a/tests/unit/test_solver_config_royalty.py
+++ b/tests/unit/test_solver_config_royalty.py
@@ -1,0 +1,13 @@
+from aichemy.solver.config import SolverConfig
+
+
+def test_solver_config_has_royalty_defaults():
+    cfg = SolverConfig()
+    assert cfg.r_process == 0.0
+    assert cfg.r_comp == 0.0
+
+
+def test_solver_config_accepts_custom_royalties():
+    cfg = SolverConfig(r_process=0.05, r_comp=0.03)
+    assert cfg.r_process == 0.05
+    assert cfg.r_comp == 0.03

--- a/tests/unit/test_solver_royalty.py
+++ b/tests/unit/test_solver_royalty.py
@@ -1,0 +1,80 @@
+"""Royalty terms in the MILP objective (Task 17).
+
+Three invariants:
+1. Zero-royalty equivalence — same objective as legacy when r_process=r_comp=0.
+2. Process royalty reduces objective by exactly r_process · price_sell · η · f.
+3. Composition royalty reduces objective by exactly r_comp · price_sell · q_sell.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+from aichemy.solver.config import SolverConfig
+from aichemy.solver.model import build_and_solve
+
+
+def _two_reaction_fixture(*, process_covered: bool, composition_covered: bool):
+    """Single reaction A + B → C; price A=1, B=1, C=10; yield 1.0; balanced=True."""
+    reactions = pl.DataFrame(
+        {
+            "rxn_id": ["RX1"],
+            "yield_rate": [1.0],
+            "reactants": [
+                [
+                    {"mol_id": "A", "coefficient": 1.0},
+                    {"mol_id": "B", "coefficient": 1.0},
+                ]
+            ],
+            "products": [[{"mol_id": "C", "coefficient": 1.0}]],
+            "rdkit_balanced": [True],
+            "balanced": [True],
+            "patent_active": [process_covered or composition_covered],
+            "process_covered": [process_covered],
+            "composition_covered": [composition_covered],
+        }
+    )
+    molecules = pl.DataFrame(
+        {
+            "mol_id": ["A", "B", "C"],
+            "price_per_gram": [1.0, 1.0, 10.0],
+        }
+    )
+    return reactions, molecules
+
+
+def test_zero_royalty_matches_baseline_objective():
+    """At r_process=r_comp=0, royalty terms are no-ops; objective matches legacy."""
+    reactions, molecules = _two_reaction_fixture(process_covered=True, composition_covered=True)
+    sol_zero = build_and_solve(reactions, molecules, SolverConfig(r_process=0.0, r_comp=0.0))
+    # Drop license columns to simulate the pre-licensing solver path.
+    reactions_legacy = reactions.drop(["patent_active", "process_covered", "composition_covered"])
+    sol_legacy = build_and_solve(reactions_legacy, molecules, SolverConfig())
+    assert abs(sol_zero.objective_value - sol_legacy.objective_value) < 1e-3
+
+
+def test_process_royalty_reduces_objective_by_expected_amount():
+    """At r_process=0.5, process-covered reaction pays 0.5 · price_sell[product] · η · f."""
+    reactions, molecules = _two_reaction_fixture(process_covered=True, composition_covered=False)
+    sol_no = build_and_solve(reactions, molecules, SolverConfig(r_process=0.0, r_comp=0.0))
+    sol_p = build_and_solve(reactions, molecules, SolverConfig(r_process=0.5, r_comp=0.0))
+    flow = sol_no.activated_reactions[0]["flow"]
+    expected_delta = 0.5 * 10.0 * 1.0 * flow  # rate · price[C] · yield · f
+    assert abs((sol_no.objective_value - sol_p.objective_value) - expected_delta) < 1e-2
+
+
+def test_composition_royalty_reduces_objective_by_expected_amount():
+    """At r_comp=0.5, composition-covered product pays 0.5 · price_sell · q_sell.
+
+    Uses a tight max_flow=1 / budget=2 config so the only economic activity is:
+    buy 1 A + 1 B → produce 1 C → sell 1 C. Eliminates the LP's degenerate
+    buy-resell of C (which would inflate q_sell[C] and make the delta
+    sensitive to the optimizer's tie-breaking).
+    """
+    reactions, molecules = _two_reaction_fixture(process_covered=False, composition_covered=True)
+    base = {"max_flow": 1.0, "budget": 2.0}
+    sol_no = build_and_solve(reactions, molecules, SolverConfig(**base, r_process=0.0, r_comp=0.0))
+    sol_c = build_and_solve(reactions, molecules, SolverConfig(**base, r_process=0.0, r_comp=0.5))
+    sold_qty = next(s for s in sol_no.sold_molecules if s["mol_id"] == "C")["quantity"]
+    expected_delta = 0.5 * 10.0 * sold_qty
+    assert abs((sol_no.objective_value - sol_c.objective_value) - expected_delta) < 1e-2


### PR DESCRIPTION
## Summary

Plan D+E of the patent-licensing rollup. Wires the license classifications produced by Plans B and C onto the augmented reactions DataFrame, adds two royalty terms to the MILP objective, and ships a sensitivity-sweep CLI.

Companion: [`docs/superpowers/specs/2026-04-25-aichemy-pricing-licensing-design.md`](docs/superpowers/specs/2026-04-25-aichemy-pricing-licensing-design.md), [`docs/superpowers/plans/2026-04-25-aichemy-pricing-licensing.md`](docs/superpowers/plans/2026-04-25-aichemy-pricing-licensing.md).

## Commits (one per task, in implementation order)

1. `feat(licensing): add r_process and r_comp to SolverConfig` (Task 16) — two new pydantic fields, default 0.0 each.
2. `feat(licensing): subtract process/composition royalty terms in MILP objective` (Task 17) — three edits to `build_and_solve()`. Existing `test_solver.py` passes unchanged (zero-royalty equivalence is the explicit invariant).
3. `feat(licensing): add augment_licenses merge step` (Task 14) — pure function joining CPC and LLM classifications onto reactions; LLM wins on ambiguous, OR-aggregate per rxn_id, MetaNetX → all False.
4. `feat(licensing): add 'aichemy augment licenses' CLI subcommand` (Task 15) — Typer wrapper on `augment_app`.
5. `feat(licensing): add 'aichemy solve sweep' subcommand for sensitivity` (Task 18) — `_run_sweep()` helper + `solve sweep` CLI; default 5x5 grid; per-cell solution.json + summary.parquet with set_hash for "decision invariance" plotting.

## Test plan

- [x] `tests/unit/test_solver.py` passes unchanged (9 existing tests — the regression bar).
- [x] `tests/unit/test_solver_config_royalty.py` passes (2 new).
- [x] `tests/unit/test_solver_royalty.py` passes (3 new — zero-royalty equivalence, process royalty, composition royalty with tight max_flow=1/budget=2 to remove a degenerate q_buy[C] tie).
- [x] `tests/unit/test_augment_licenses.py` passes (4 new — MetaNetX → all-False, USPTO unambiguous → CPC, USPTO ambiguous → LLM, USPTO ambiguous w/o LLM → False).
- [x] `tests/unit/test_solve_sweep.py` passes (3 new — grid summary shape, set_hash divergence at high royalty, per-cell solution.json).
- [x] Full unit suite: 223 pass, 2 unchanged pre-existing `test_balance_syn_rbl.py` failures (optional `synrbl` extra not installed in worktree venv — reproduces on `licensing-integration` without `[balance]`).
- [x] `uv run mypy src/` — 53 source files clean.
- [x] `uv run ruff check .` and `uv run ruff format --check .` — clean.
- [x] CLI: `uv run aichemy augment licenses --help` and `uv run aichemy solve sweep --help` register.

## Notes

- Targets `licensing-integration` per the explicit ultraplan args. Not main.
- Built on top of B+C (`licensing-integration` HEAD = `eb6eae3`) so the merge step's join keys (`patent_number` on CPC and LLM, the column names from `CPC_CLASSIFICATION_SCHEMA`/`LLM_CLASSIFICATION_SCHEMA` produced by `patents/cpc.py` and `patents/llm_classify.py`) are validated against actual upstream code, not just the spec.
- Implemented in a worktree separate from the user's primary working directory to avoid `uv sync` cross-contamination of their active venv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)