### PR TITLE
feat(pricing): Browserbase Browser API L3 path (Sub-Plan G)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ pricing = [
   "pydantic>=2.6",
   "typer>=0.12",
   "rdkit>=2024.3",
-  "html2text>=2024.2",  # Browserbase Fetch returns HTML; we convert to markdown
+  "html2text>=2024.2",      # Browserbase Fetch returns HTML; we convert to markdown
+  "browserbase>=1.0,<2.0",  # Browser API SDK — JS-rendered SPA vendors via CDP
 ]
 
 [project.scripts]

--- a/src/aichemy_pricing/browserbase/__init__.py
+++ b/src/aichemy_pricing/browserbase/__init__.py
@@ -1,14 +1,23 @@
-"""L3 fallback layer — Browserbase Fetch API.
+"""L3 fallback layer — Browserbase Fetch + Browser APIs.
 
-Public surface is `BrowserbaseClient` (one POST per page → rendered markdown)
-and `BrowserbaseFetchLookup` (the `PriceLookup` impl that the default chain
-in sub-plan E composes after the L2 httpx vendors).
+Public surface:
 
-Per-vendor markdown parsers are an internal registry concern under
-`aichemy_pricing.browserbase.parsers` — not re-exported.
+* ``BrowserbaseClient`` — one POST per page → rendered HTML→markdown (no JS)
+* ``BrowserbaseFetchLookup`` — PriceLookup over the Fetch API (cheap, SSR vendors)
+* ``BrowserbaseBrowserLookup`` — PriceLookup over a Playwright/CDP Chrome
+  session (paid, JS-rendered SPA vendors)
+
+Per-vendor parsers live under ``aichemy_pricing.browserbase.parsers`` (Fetch)
+and ``aichemy_pricing.browserbase.browser_parsers`` (Browser API) — not
+re-exported.
 """
 
+from aichemy_pricing.browserbase.browser_api import BrowserbaseBrowserLookup
 from aichemy_pricing.browserbase.client import BrowserbaseClient
 from aichemy_pricing.browserbase.fetch_lookup import BrowserbaseFetchLookup
 
-__all__ = ["BrowserbaseClient", "BrowserbaseFetchLookup"]
+__all__ = [
+    "BrowserbaseBrowserLookup",
+    "BrowserbaseClient",
+    "BrowserbaseFetchLookup",
+]

--- a/src/aichemy_pricing/browserbase/browser_api.py
+++ b/src/aichemy_pricing/browserbase/browser_api.py
@@ -1,29 +1,63 @@
-"""STUB: Browser API path — full Playwright/CDP automation.
+"""L3 Browser API path — Playwright + Browserbase Chrome session.
 
-Use when L3 needs to click a "show price" button, navigate paginated
-listings, fill an institutional-account login, or otherwise interact with
-the page beyond a single rendered fetch. Browserbase Browser API spins up
-a cloud Chrome session billed per minute.
+Use when L3 needs JavaScript execution: SPA vendors (Enamine, Cayman,
+Sigma, Tocris) return their unhydrated shell to the Fetch path. Browser
+API spins up a real Chrome session in the cloud, drives it via CDP, and
+reads ``page.content()`` after hydration.
 
-NOT IMPLEMENTED in v1. The Fetch API path (fetch_lookup.py) covers all
-verified L3 vendors — no vendor in scope requires multi-step automation.
+Each lookup is a one-shot session — no pooling. Cost: ~$0.10/hour billed
+per minute, ~10s per lookup, ~$0.0003 each. Sessions close in a finally
+block so an exception doesn't leak billable session time.
+
+A vendor is supported only after empirical calibration of its
+``WAIT_AFTER_LOAD_MS`` and parser regex; see ``browser_parsers/``.
 """
 
 from __future__ import annotations
 
+import logging
+
+from aichemy_pricing.browserbase.browser_parsers import REGISTRY
+from aichemy_pricing.browserbase.browser_session import browser_session
+from aichemy_pricing.browserbase.client import _html_to_markdown
 from aichemy_pricing.types import PriceQuote, VendorRef
+
+log = logging.getLogger(__name__)
 
 
 class BrowserbaseBrowserLookup:
+    """L3 fallback that executes JavaScript via Browserbase Browser API."""
+
     name = "browserbase_browser"
 
-    def __init__(self) -> None:
-        raise NotImplementedError(
-            "BrowserbaseBrowserLookup: not implemented in v1. The Fetch API "
-            "path (BrowserbaseFetchLookup) covers all verified L3 vendors. "
-            "Build this only when a vendor needs multi-step browser interaction "
-            "that a single Fetch call cannot satisfy."
-        )
+    def __init__(
+        self,
+        api_key: str | None = None,
+        project_id: str | None = None,
+    ) -> None:
+        self._api_key = api_key
+        self._project_id = project_id
 
     def lookup(self, ref: VendorRef) -> PriceQuote | None:
-        raise NotImplementedError
+        parser = REGISTRY.get(ref.vendor)
+        if parser is None:
+            log.debug("no Browser API parser for vendor=%s; skipping", ref.vendor)
+            return None
+        url = parser.URL_TEMPLATE.format(sku=ref.sku)
+        try:
+            with browser_session(api_key=self._api_key, project_id=self._project_id) as page:
+                if page is None:
+                    return None  # API key not configured
+                page.goto(url, wait_until="load")
+                page.wait_for_timeout(parser.WAIT_AFTER_LOAD_MS)
+                html = page.content()
+        except Exception as exc:
+            log.warning("Browser API navigation %s failed: %s", url, exc)
+            return None
+        markdown = _html_to_markdown(html)
+        try:
+            quote: PriceQuote | None = parser.parse(markdown, ref.sku)
+            return quote
+        except Exception as exc:
+            log.warning("Browser API parser %s raised on sku=%s: %s", ref.vendor, ref.sku, exc)
+            return None

--- a/src/aichemy_pricing/browserbase/browser_parsers/__init__.py
+++ b/src/aichemy_pricing/browserbase/browser_parsers/__init__.py
@@ -1,0 +1,27 @@
+"""Registry: vendor name → browser-parser config.
+
+A browser parser is a module exposing:
+
+* ``URL_TEMPLATE``: ``"https://...{sku}..."`` formatted with the VendorRef sku
+* ``WAIT_AFTER_LOAD_MS``: milliseconds to wait after ``load`` event for SPA
+  hydration before reading ``page.content()``. SPAs almost never reach
+  ``networkidle``; use a fixed wait calibrated per vendor.
+* ``parse(markdown, sku)``: same shape as ``parsers/`` modules — a
+  PriceQuote or None. Browser parsers consume html2text-converted page
+  HTML, so the same regex parsers can in principle be reused once the
+  hydrated content is in scope.
+
+Only vendors empirically validated on the Browser API live here. Adding
+a vendor: probe with the live capture script, calibrate
+WAIT_AFTER_LOAD_MS until prices appear, write the parser, register here.
+"""
+
+from __future__ import annotations
+
+from types import ModuleType
+
+from aichemy_pricing.browserbase.browser_parsers import enamine
+
+REGISTRY: dict[str, ModuleType] = {
+    "enamine": enamine,
+}

--- a/src/aichemy_pricing/browserbase/browser_parsers/enamine.py
+++ b/src/aichemy_pricing/browserbase/browser_parsers/enamine.py
@@ -1,0 +1,49 @@
+"""Enamine browser-parser config (L3 Browser API).
+
+Empirically validated 2026-04-26: enaminestore.com is a CRA/SPA shell
+("enable JavaScript" in the unhydrated body). Browserbase Browser API
+hydrates it; Playwright reads ``page.content()`` after an 8s post-load
+wait, html2text converts to markdown, and the regex below extracts pack
+sizes + prices from the rendered catalog rows.
+
+URL shape per CLAIM-07: ``enaminestore.com/catalog/EN300-{N}`` (NOT the
+``enamine.net`` variant, which serves a different React route).
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime
+
+from aichemy_pricing.types import PriceQuote
+from aichemy_pricing.vendors._common import pack_size_to_grams, strip_molarity_tokens
+
+URL_TEMPLATE = "https://enaminestore.com/catalog/{sku}"
+WAIT_AFTER_LOAD_MS = 8_000
+
+_PACK_PRICE_RE = re.compile(
+    r"([\d.]+)\s*(mg|g|kg|µg|ug|mcg)\b[^$]{0,400}\$\s*([\d,]+(?:\.\d+)?)",
+    re.I | re.S,
+)
+
+
+def parse(markdown: str, sku: str) -> PriceQuote | None:
+    text = strip_molarity_tokens(markdown)
+    m = _PACK_PRICE_RE.search(text)
+    if not m:
+        return None
+    try:
+        size = float(m.group(1))
+        unit = m.group(2).lower()
+        price = float(m.group(3).replace(",", ""))
+    except ValueError:
+        return None
+    return PriceQuote(
+        vendor="enamine",
+        sku=sku,
+        price=price,
+        currency="USD",
+        pack_size_g=pack_size_to_grams(size, unit),
+        fetched_at=datetime.now(UTC),
+        raw={"source": "browserbase_browser", "url_template": URL_TEMPLATE},
+    )

--- a/src/aichemy_pricing/browserbase/browser_session.py
+++ b/src/aichemy_pricing/browserbase/browser_session.py
@@ -1,0 +1,83 @@
+"""Browserbase Browser API session lifecycle helper.
+
+Browserbase Fetch (client.py) does not execute JavaScript, so SPA vendors
+(Enamine, Cayman, Sigma, Tocris) return their unhydrated shell. Browser
+API spins up a real Chrome session that we drive with Playwright over CDP.
+
+Cost: per-minute billing at ~$0.10/hour. A typical lookup is ~10s of
+session time. The context manager guarantees `session.close()` runs even
+when the page raises — a leaked session keeps billing.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+from collections.abc import Iterator
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from playwright.sync_api import Page
+
+log = logging.getLogger(__name__)
+
+
+@contextlib.contextmanager
+def browser_session(
+    api_key: str | None = None,
+    project_id: str | None = None,
+    nav_timeout_ms: int = 30_000,
+) -> Iterator[Page | None]:
+    """Yield a Playwright Page connected to a one-shot Browserbase Chrome session.
+
+    Caller drives the page (navigate, wait, extract). Cleanup — page close,
+    context close, browser disconnect, Browserbase session close — runs in
+    a finally block whether or not the body raised.
+
+    Yields None when BROWSERBASE_API_KEY is unset; callers must treat that
+    as "Browser API unavailable, skip vendor".
+    """
+    key = api_key or os.environ.get("BROWSERBASE_API_KEY")
+    if not key:
+        log.debug("browser_session: BROWSERBASE_API_KEY unset; yielding None")
+        yield None
+        return
+
+    from browserbase import Browserbase
+    from playwright.sync_api import sync_playwright
+
+    bb = Browserbase(api_key=key)
+    pid = project_id or _default_project_id(bb)
+    session = bb.sessions.create(project_id=pid)
+
+    pw = None
+    browser = None
+    try:
+        pw = sync_playwright().start()
+        browser = pw.chromium.connect_over_cdp(session.connect_url)
+        context = browser.contexts[0]
+        page = context.pages[0] if context.pages else context.new_page()
+        page.set_default_navigation_timeout(nav_timeout_ms)
+        yield page
+    finally:
+        with contextlib.suppress(Exception):
+            if browser is not None:
+                browser.close()
+        with contextlib.suppress(Exception):
+            if pw is not None:
+                pw.stop()
+        with contextlib.suppress(Exception):
+            bb.sessions.update(
+                id=session.id,
+                project_id=pid,
+                status="REQUEST_RELEASE",
+            )
+
+
+def _default_project_id(bb: object) -> str:
+    """Return the first project's id — Browserbase accounts have a default project."""
+    projects = bb.projects.list()  # type: ignore[attr-defined]
+    if not projects:
+        raise RuntimeError("Browserbase account has no projects")
+    return str(projects[0].id)

--- a/src/aichemy_pricing/tests/test_browserbase_browser_lookup.py
+++ b/src/aichemy_pricing/tests/test_browserbase_browser_lookup.py
@@ -1,0 +1,137 @@
+"""Unit tests for BrowserbaseBrowserLookup.
+
+Mocks the Playwright/Browserbase session via the ``browser_session`` context
+manager so tests are fully offline. Live tests require BROWSERBASE_API_KEY
+and are marked ``@pytest.mark.live``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from aichemy_pricing.browserbase import browser_api as browser_api_mod
+from aichemy_pricing.browserbase import browser_parsers as browser_parsers_pkg
+from aichemy_pricing.browserbase.browser_api import BrowserbaseBrowserLookup
+from aichemy_pricing.types import PriceQuote, VendorRef
+
+
+def _quote(vendor: str = "stub") -> PriceQuote:
+    return PriceQuote(
+        vendor=vendor,
+        sku="x",
+        price=1.0,
+        currency="USD",
+        pack_size_g=1.0,
+        fetched_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+
+
+def _stub_parser(
+    returns: PriceQuote | None = None,
+    raises: Exception | None = None,
+    record: list[tuple[str, str]] | None = None,
+    wait_ms: int = 0,
+) -> SimpleNamespace:
+    def parse(markdown: str, sku: str) -> PriceQuote | None:
+        if record is not None:
+            record.append((markdown, sku))
+        if raises is not None:
+            raise raises
+        return returns
+
+    return SimpleNamespace(
+        URL_TEMPLATE="https://example.test/{sku}",
+        WAIT_AFTER_LOAD_MS=wait_ms,
+        parse=parse,
+    )
+
+
+def _fake_session_factory(page: MagicMock | None):
+    """Build a context-manager that yields ``page`` (or None for unconfigured)."""
+
+    @contextlib.contextmanager
+    def factory(api_key=None, project_id=None):
+        yield page
+
+    return factory
+
+
+def test_returns_none_when_vendor_not_in_registry() -> None:
+    out = BrowserbaseBrowserLookup().lookup(VendorRef(vendor="not-a-real-vendor", sku="x"))
+    assert out is None
+
+
+def test_returns_none_when_session_unconfigured(monkeypatch) -> None:
+    monkeypatch.setitem(
+        browser_parsers_pkg.REGISTRY, "stub-vendor", _stub_parser(returns=_quote("stub-vendor"))
+    )
+    monkeypatch.setattr(browser_api_mod, "browser_session", _fake_session_factory(page=None))
+    out = BrowserbaseBrowserLookup().lookup(VendorRef(vendor="stub-vendor", sku="abc"))
+    assert out is None
+
+
+def test_navigates_and_dispatches_to_parser(monkeypatch) -> None:
+    expected = _quote("stub-vendor")
+    record: list[tuple[str, str]] = []
+    monkeypatch.setitem(
+        browser_parsers_pkg.REGISTRY,
+        "stub-vendor",
+        _stub_parser(returns=expected, record=record, wait_ms=42),
+    )
+
+    page = MagicMock()
+    page.content.return_value = "<html><body>10 g $1.00</body></html>"
+    monkeypatch.setattr(browser_api_mod, "browser_session", _fake_session_factory(page=page))
+
+    out = BrowserbaseBrowserLookup().lookup(VendorRef(vendor="stub-vendor", sku="abc"))
+    assert out is expected
+    page.goto.assert_called_once_with("https://example.test/abc", wait_until="load")
+    page.wait_for_timeout.assert_called_once_with(42)
+    assert len(record) == 1
+    assert record[0][1] == "abc"
+    # html2text-converted markdown reaches the parser, not raw HTML.
+    assert "<html>" not in record[0][0]
+
+
+def test_returns_none_when_navigation_raises(monkeypatch) -> None:
+    monkeypatch.setitem(
+        browser_parsers_pkg.REGISTRY, "stub-vendor", _stub_parser(returns=_quote("stub-vendor"))
+    )
+    page = MagicMock()
+    page.goto.side_effect = RuntimeError("net::ERR_TIMED_OUT")
+    monkeypatch.setattr(browser_api_mod, "browser_session", _fake_session_factory(page=page))
+
+    out = BrowserbaseBrowserLookup().lookup(VendorRef(vendor="stub-vendor", sku="abc"))
+    assert out is None
+
+
+def test_returns_none_when_parser_raises(monkeypatch) -> None:
+    monkeypatch.setitem(
+        browser_parsers_pkg.REGISTRY,
+        "stub-vendor",
+        _stub_parser(raises=RuntimeError("boom")),
+    )
+    page = MagicMock()
+    page.content.return_value = "<html></html>"
+    monkeypatch.setattr(browser_api_mod, "browser_session", _fake_session_factory(page=page))
+
+    out = BrowserbaseBrowserLookup().lookup(VendorRef(vendor="stub-vendor", sku="abc"))
+    assert out is None
+
+
+@pytest.mark.live
+def test_browser_lookup_live_enamine() -> None:
+    """Hits real Browserbase Browser API against Enamine. Requires BROWSERBASE_API_KEY."""
+    if not os.environ.get("BROWSERBASE_API_KEY"):
+        pytest.skip("BROWSERBASE_API_KEY not set")
+    out = BrowserbaseBrowserLookup().lookup(VendorRef(vendor="enamine", sku="EN300-7605608"))
+    # Either the SPA hydrated and we got a quote, or the upstream had no
+    # price for this SKU and we got None — both are acceptable; the point
+    # is no exception escapes and (when present) the quote is well-formed.
+    assert out is None or (out.vendor == "enamine" and out.price > 0 and out.pack_size_g > 0)

--- a/src/aichemy_pricing/tests/test_browserbase_browser_parser_enamine.py
+++ b/src/aichemy_pricing/tests/test_browserbase_browser_parser_enamine.py
@@ -1,0 +1,23 @@
+"""Unit tests for the L3 Enamine browser-parser."""
+
+from __future__ import annotations
+
+from aichemy_pricing.browserbase.browser_parsers import enamine
+
+
+def test_enamine_browser_parser_extracts_pack_price() -> None:
+    md = "# EN300-7605608\n\n50 mg  $42.00\n100 mg  $78.00\n"
+    quote = enamine.parse(md, sku="EN300-7605608")
+    assert quote is not None
+    assert quote.vendor == "enamine"
+    assert quote.sku == "EN300-7605608"
+    assert quote.currency == "USD"
+    assert quote.price == 42.0
+    # 50 mg = 0.05 g
+    assert abs(quote.pack_size_g - 0.05) < 1e-9
+    assert quote.raw is not None and quote.raw.get("source") == "browserbase_browser"
+
+
+def test_enamine_browser_parser_returns_none_on_unmatched() -> None:
+    quote = enamine.parse("nothing useful here", sku="EN300-NOPE")
+    assert quote is None

--- a/src/aichemy_pricing/tests/test_browserbase_stubs.py
+++ b/src/aichemy_pricing/tests/test_browserbase_stubs.py
@@ -1,26 +1,19 @@
-"""Lock the Browser API + LLM extraction modules as STUBS.
+"""Lock the LLM extraction module as a STUB.
 
-These tests prevent the stubs from accidentally shipping as half-working
-implementations. If you intentionally implement either of these in a
+This test prevents the LLM stub from accidentally shipping as a
+half-working implementation. If you intentionally implement it in a
 future revision, update or remove the test (don't keep a fake-passing
 stub assertion in place).
+
+(BrowserbaseBrowserLookup was a stub in sub-plan F and is now real —
+its tests live in test_browserbase_browser_lookup.py.)
 """
 
 from __future__ import annotations
 
 import pytest
 
-from aichemy_pricing.browserbase.browser_api import BrowserbaseBrowserLookup
 from aichemy_pricing.browserbase.llm_extract import BrowserbaseLLMLookup
-
-
-def test_browser_api_constructor_raises_with_helpful_message() -> None:
-    with pytest.raises(NotImplementedError) as exc_info:
-        BrowserbaseBrowserLookup()
-    msg = str(exc_info.value)
-    # Must point the future-implementer at when to swap the stub for a
-    # real impl — not just say "TODO".
-    assert "Fetch API" in msg or "multi-step" in msg
 
 
 def test_llm_extract_constructor_raises_with_helpful_message() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -47,6 +47,7 @@ notebooks = [
     { name = "pandas" },
 ]
 pricing = [
+    { name = "browserbase" },
     { name = "curl-cffi" },
     { name = "html2text" },
     { name = "httpx" },
@@ -78,6 +79,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.40.0" },
+    { name = "browserbase", marker = "extra == 'pricing'", specifier = ">=1.0,<2.0" },
     { name = "curl-cffi", marker = "extra == 'pricing'", specifier = ">=0.7" },
     { name = "equilibrator-api", marker = "extra == 'thermo'", specifier = ">=0.7.0" },
     { name = "gurobipy", marker = "extra == 'solver'", specifier = ">=11.0" },
@@ -648,6 +650,23 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/d9/d5340b43cf5fbe7fe5a083d237e5338cc1caa73bea523be1c5e452c26290/brotlicffi-1.2.0.1-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:37cb587d32bf7168e2218c455e22e409ad1f3157c6c71945879a311f3e6b6abf", size = 406710, upload-time = "2026-03-05T19:54:07.272Z" },
     { url = "https://files.pythonhosted.org/packages/a3/82/dbced4c1e0792efdf23fd90ff6d2a320c64ff4dfef7aacc85c04fde9ddd2/brotlicffi-1.2.0.1-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d6ba65dd528892b4d9960beba2ae011a753620bcfc66cf6fa3cee18d7b0baa4", size = 402787, upload-time = "2026-03-05T19:54:08.73Z" },
     { url = "https://files.pythonhosted.org/packages/ef/6f/534205ba7590c9a8716a614f270c5c2ec419b5b7079b3f9cd31b7b5580de/brotlicffi-1.2.0.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:f2a5575653b0672638ba039b82fda56854934d7a6a24d4b8b5033f73ab43cbc1", size = 375108, upload-time = "2026-03-05T19:54:10.079Z" },
+]
+
+[[package]]
+name = "browserbase"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/07/4ab4b91921833d0fb1731940d74141396d83120821f4c85482ed80bb2457/browserbase-1.8.0.tar.gz", hash = "sha256:dc62910c2f1fab3e944f338af9fbf82f53bbffcb3aeb6382b4e435a752383011", size = 147213, upload-time = "2026-04-06T19:31:26.848Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/c3/a29e57566c52fdb24712dcbb93a9bc97937c0c75874d8880a41a651daa5c/browserbase-1.8.0-py3-none-any.whl", hash = "sha256:4c4215973cc99f2f6d34550ae105c3f1f83b5fe22df2845bea0920b10f809526", size = 110012, upload-time = "2026-04-06T19:31:25.765Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds `BrowserbaseBrowserLookup` — a `PriceLookup` that drives a Browserbase Chrome session via Playwright + CDP. Replaces the previous `NotImplementedError` stub from sub-plan F.
- Reaches SPA-only vendors that the Fetch path can't (Fetch does not execute JS). Enamine is the first vendor empirically validated; live test confirms `$32 / 50 mg` for `EN300-7605608` in 13s.
- Per-vendor configs live under `browserbase/browser_parsers/` with a tiny REGISTRY. Adding Cayman / Sigma / Tocris is a one-file change after each is empirically calibrated.

## Why both Fetch and Browser?
PR #27 (sub-plan F) ships the Fetch path for ChemCruz (the only vendor that returns SSR HTML with prices). This PR ships the Browser path for the rest. They compose in the chain — Fetch first (cheaper), Browser as fallback (paid per minute, ~\$0.0003 per lookup at ~10s).

## Cost guard
`browser_session` is a context manager with `finally`-clause cleanup. An exception inside the `with` cannot leak a billable session.

## Stacking
This PR's base is `pricing-integration`, but its branch is stacked on `feat/pricing-F-browserbase-l3` (PR #27). Merge PR #27 first; this rebases to a clean diff.

## Test plan
- [x] Unit tests for `BrowserbaseBrowserLookup` (mocked Playwright via the `browser_session` context manager): registry miss, unconfigured key, navigate+dispatch, navigation-raise, parser-raise.
- [x] Unit tests for the Enamine browser parser (synthetic markdown).
- [x] `mypy --strict` and `ruff` clean.
- [x] Live test against real Browserbase + Enamine: `BROWSERBASE_API_KEY=… pytest -m live -k live_enamine` returns a real `PriceQuote(price=32.0, pack_size_g=0.05)` in 13s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)