### PR TITLE
feat(licensing): DVC integration + e2e test (Tasks 19–20)

### DIFF
--- a/dvc.yaml
+++ b/dvc.yaml
@@ -114,6 +114,49 @@ stages:
     outs:
       - data/interim/augmented/reactions_full.parquet
 
+  fetch_patent_metadata:
+    cmd: uv run aichemy patents fetch --config configs/default.yaml
+    deps:
+      - configs/default.yaml
+      - src/aichemy/preprocessing/patents/fetch.py
+      - data/interim/augmented/reactions_full.parquet
+    outs:
+      - data/interim/patents/patent_metadata.parquet
+
+  classify_licenses_cpc:
+    cmd: uv run aichemy patents classify-cpc --config configs/default.yaml
+    deps:
+      - configs/default.yaml
+      - configs/cpc_rules.yaml
+      - src/aichemy/preprocessing/patents/cpc.py
+      - data/interim/augmented/reactions_full.parquet
+      - data/interim/patents/patent_metadata.parquet
+    outs:
+      - data/interim/licenses/cpc_classifications.parquet
+
+  classify_licenses_llm:
+    cmd: uv run aichemy patents classify-llm --config configs/default.yaml
+    deps:
+      - configs/default.yaml
+      - src/aichemy/preprocessing/patents/llm_classify.py
+      - src/aichemy/preprocessing/patents/cache.py
+      - data/interim/licenses/cpc_classifications.parquet
+      - data/interim/patents/patent_metadata.parquet
+    outs:
+      - data/interim/licenses/llm_classifications.parquet
+      - data/interim/licenses/llm_cache.jsonl
+
+  augment_licenses:
+    cmd: uv run aichemy augment licenses --config configs/default.yaml
+    deps:
+      - configs/default.yaml
+      - src/aichemy/preprocessing/augment/licenses.py
+      - data/interim/augmented/reactions_full.parquet
+      - data/interim/licenses/cpc_classifications.parquet
+      - data/interim/licenses/llm_classifications.parquet
+    outs:
+      - data/interim/augmented/reactions_licensed.parquet
+
   augment_prices:
     cmd: uv run aichemy augment prices --config configs/default.yaml
     deps:
@@ -130,7 +173,7 @@ stages:
       - configs/default.yaml
       - src/aichemy/preprocessing/export.py
       - data/interim/augmented/molecules_priced.parquet
-      - data/interim/augmented/reactions_full.parquet
+      - data/interim/augmented/reactions_licensed.parquet
     outs:
       - data/processed/reactions.parquet
       - data/processed/molecules.parquet

--- a/src/aichemy/cli.py
+++ b/src/aichemy/cli.py
@@ -779,7 +779,7 @@ def export(
 ) -> None:
     """Write final unified hypergraph parquets + manifest.json to data/processed/."""
     cfg = _load(config, override)
-    reactions_in = interim_path(cfg, "augmented", "reactions_full.parquet")
+    reactions_in = interim_path(cfg, "augmented", "reactions_licensed.parquet")
     molecules_in = interim_path(cfg, "augmented", "molecules_priced.parquet")
     reactions_out = processed_path(cfg, "reactions.parquet")
     molecules_out = processed_path(cfg, "molecules.parquet")

--- a/tests/integration/test_dvc_repro_licenses.py
+++ b/tests/integration/test_dvc_repro_licenses.py
@@ -1,0 +1,156 @@
+"""End-to-end integration test for the licensing stages.
+
+Runs the four new pipeline stages on a tiny synthetic fixture, with
+PatentsView calls stubbed via ``responses`` and Anthropic calls stubbed
+via a ``MagicMock`` client. Verifies the data flows through to the
+``augment_licenses`` output with correct columns for both USPTO and
+MetaNetX rows (the latter exercises the left-join + ``fill_null(False)``
+fallback path).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import polars as pl
+import pytest
+import responses
+
+PATENTSVIEW = "https://search.patentsview.org/api/v1/patent"
+
+
+@pytest.fixture
+def fake_reactions_full(tmp_path: Path) -> Path:
+    df = pl.DataFrame(
+        {
+            "rxn_id": ["USPTO:7456123:0", "MNXR1"],
+            "reaction_smiles": ["A.B>>C", "X>>Y"],
+            "reactants": [
+                [{"mol_id": "A", "coefficient": 1.0}, {"mol_id": "B", "coefficient": 1.0}],
+                [{"mol_id": "X", "coefficient": 1.0}],
+            ],
+            "products": [
+                [{"mol_id": "C", "coefficient": 1.0}],
+                [{"mol_id": "Y", "coefficient": 1.0}],
+            ],
+            "type": ["chemical", "enzymatic"],
+            "yield_rate": [0.85, 0.95],
+            "delta_g": [None, None],
+            "balanced": [True, True],
+            "source": ["uspto", "metanetx"],
+        }
+    )
+    out = tmp_path / "reactions_full.parquet"
+    df.write_parquet(out)
+    return out
+
+
+@responses.activate
+def test_full_license_flow_with_stubbed_apis(
+    tmp_path: Path,
+    fake_reactions_full: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    responses.add(
+        responses.POST,
+        PATENTSVIEW,
+        json={
+            "patents": [
+                {
+                    "patent_number": "7456123",
+                    "patent_date": "2008-11-25",
+                    "patent_abstract": "A medicinal preparation for…",
+                    "claims": [{"text": "1. A composition comprising…"}],
+                    "cpcs": [{"cpc_group_id": "A61K 31/505"}],
+                    "assignees": [{"assignee_organization": "Acme"}],
+                    "application": {"filing_date": "2015-03-14"},
+                }
+            ]
+        },
+        status=200,
+    )
+
+    fake_block = MagicMock()
+    fake_block.type = "tool_use"
+    fake_block.name = "report_classification"
+    fake_block.input = {
+        "process_covered": False,
+        "composition_covered": True,
+        "confidence": 0.9,
+        "rationale": "Independent claim 1 is composition-of-matter.",
+    }
+    fake_msg = MagicMock()
+    fake_msg.stop_reason = "tool_use"
+    fake_msg.content = [fake_block]
+    fake_client = MagicMock()
+    fake_client.messages.create.return_value = fake_msg
+
+    import anthropic
+
+    monkeypatch.setattr(anthropic, "Anthropic", lambda *a, **kw: fake_client)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "fake-key-for-test")
+
+    from aichemy.preprocessing.augment.licenses import augment_licenses
+    from aichemy.preprocessing.patents.cpc import (
+        classify_dataframe,
+        load_cpc_rules,
+    )
+    from aichemy.preprocessing.patents.fetch import (
+        fetch_patents,
+        write_metadata_parquet,
+    )
+    from aichemy.preprocessing.patents.llm_classify import (
+        classify_ambiguous_patents,
+    )
+
+    reactions = pl.read_parquet(fake_reactions_full)
+
+    # 1. fetch_patent_metadata
+    items = fetch_patents(["7456123"], endpoint=PATENTSVIEW, max_retries=1)
+    patents_path = tmp_path / "patent_metadata.parquet"
+    write_metadata_parquet(items, patents_path)
+
+    # 2. classify_licenses_cpc
+    rules = load_cpc_rules(Path("configs/cpc_rules.yaml"))
+    cpc_df = classify_dataframe(
+        reactions,
+        pl.read_parquet(patents_path),
+        rules=rules,
+        today=date(2026, 4, 25),
+    )
+    cpc_path = tmp_path / "cpc.parquet"
+    cpc_df.write_parquet(cpc_path)
+
+    # 3. classify_licenses_llm
+    llm_df = classify_ambiguous_patents(
+        cpc=cpc_df,
+        patents=pl.read_parquet(patents_path),
+        reactions=reactions,
+        cache_path=tmp_path / "cache.jsonl",
+        out_path=tmp_path / "llm.parquet",
+        client=fake_client,
+        model="claude-haiku-4-5",
+        max_retries=1,
+    )
+
+    # 4. augment_licenses
+    out = augment_licenses(reactions, cpc_df, llm_df)
+
+    # Schema: all three license columns present.
+    assert {"patent_active", "process_covered", "composition_covered"} <= set(out.columns)
+
+    by_rxn = {r["rxn_id"]: r for r in out.iter_rows(named=True)}
+
+    # USPTO row: A61K is in ambiguous_codes → LLM verdict (False, True) wins.
+    # filing_date 2015-03-14 + 20y = 2035-03-14 > today=2026-04-25 → active.
+    assert by_rxn["USPTO:7456123:0"]["patent_active"] is True
+    assert by_rxn["USPTO:7456123:0"]["process_covered"] is False
+    assert by_rxn["USPTO:7456123:0"]["composition_covered"] is True
+
+    # MetaNetX row: source=="metanetx" is excluded from cpc_df by
+    # classify_dataframe, then left-joined back as null and fill_null(False).
+    assert by_rxn["MNXR1"]["patent_active"] is False
+    assert by_rxn["MNXR1"]["process_covered"] is False
+    assert by_rxn["MNXR1"]["composition_covered"] is False


### PR DESCRIPTION
## Summary

Sub-plan **F** (DVC integration) for the licensing pipeline. Wires the four licensing stages into `dvc.yaml` and adds an end-to-end integration test. Targets `licensing-integration` (not `main`) — the user will run subsample DVC tests on this branch before opening the rollup PR to main.

## Changes

- `dvc.yaml`: insert four stages between `augment_directionality` and `augment_prices`:
  - `fetch_patent_metadata` → `data/interim/patents/patent_metadata.parquet`
  - `classify_licenses_cpc` → `data/interim/licenses/cpc_classifications.parquet`
  - `classify_licenses_llm` → `data/interim/licenses/llm_classifications.parquet`, `llm_cache.jsonl`
  - `augment_licenses` → `data/interim/augmented/reactions_licensed.parquet`
- `dvc.yaml`: `export.deps` swap `reactions_full.parquet` → `reactions_licensed.parquet`.
- `src/aichemy/cli.py:782` (`@app.command("export")`): same swap on the actual file read.
- `tests/integration/test_dvc_repro_licenses.py`: new — runs the four stage functions in sequence on a two-row fixture (one USPTO, one MetaNetX), with PatentsView stubbed via `responses` and Anthropic via `MagicMock`.

`augment_prices` is left untouched (joins on molecules, doesn't need license columns). The other three CLI reads of `reactions_full.parquet` (`patents fetch`, `patents classify-cpc`, `patents classify-llm`) are correct as-is — they run *before* the merge.

## Discrepancies vs. the plan doc

The implementation deviates from `docs/superpowers/plans/2026-04-25-aichemy-pricing-licensing.md` in two places, verified against `licensing-integration` HEAD:

1. **Path string lives in `cli.py`, not `export.py`.** The plan says to update `src/aichemy/preprocessing/export.py`; that file is helpers only. The actual read is `cli.py:782`.
2. **CPC rules path is `configs/cpc_rules.yaml` (plural), not `config/cpc_rules.yaml`.** Both the dvc.yaml dep and the integration test fixture path use the plural form.

## Verification

- `uv run dvc dag` shows all four new stages between `augment_directionality` and `export`, no cycles, `augment_prices` unchanged. (`augment_directionality → {fetch_patent_metadata, classify_licenses_cpc, augment_licenses, augment_prices}`; `fetch_patent_metadata → {classify_licenses_cpc, classify_licenses_llm}`; `{classify_licenses_cpc, classify_licenses_llm} → augment_licenses`; `{augment_licenses, augment_prices} → export`.)
- `uv run pytest tests/integration/test_dvc_repro_licenses.py -v` → PASS.
- All 36 license-related tests pass: `tests/unit/test_augment_licenses.py`, `test_patents_cpc.py`, `test_patents_fetch.py`, `test_patents_llm_classify.py`, `test_patents_llm_cache.py`, `test_solver_royalty.py`, `test_solve_sweep.py`, `test_io_license_columns.py`, `test_config_licenses.py`, plus the new integration test.
- Two pre-existing failures (`test_balance_syn_rbl.py` × 2) reproduce on the `licensing-integration` baseline without these changes — they require optional `synrbl` extra (`uv sync --extra balance`). The transient `test_fetch_raw_stub_creates_raw_directories` flake is a real 503 from metanetx.org.

## Test plan

- [ ] Reviewer runs `uv run dvc dag` and confirms the four new stages appear in the right place.
- [ ] Reviewer runs `uv run pytest tests/integration/test_dvc_repro_licenses.py -v` → PASS.
- [ ] User runs subsample `uv run dvc repro` on this branch and confirms `data/processed/reactions.parquet` has populated `patent_active`, `process_covered`, `composition_covered` columns.

https://claude.ai/code/session_016MYewpTKVdQ54AVBoo3oTE

---
_Generated by [Claude Code](https://claude.ai/code/session_016MYewpTKVdQ54AVBoo3oTE)_