### PR TITLE
feat(pricing): Sub-Plan E — CLI + AIchemy integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,64 @@ Override semantics: dict-valued keys deep-merge; scalars and lists are **replace
 - `research_reports/` — literature review (SPARROW, ASKCOS, minChemBio, etc.)
 - `docs/superpowers/specs/2026-04-19-repo-layout-design.md` — this repo's design spec
 - `docs/superpowers/plans/2026-04-19-preprocessing-foundation.md` — implementation plan (this scaffolding)
+
+## Vendor pricing
+
+`aichemy-pricing` is a standalone package (sibling to `aichemy`) that resolves
+chemical identifiers to per-gram prices via a tiered chain of verified vendor
+sources, then converts to USD via a static FX table.
+
+**Install + verify:**
+```bash
+uv sync --extra pricing
+uv run aichemy-price --version
+```
+
+**Single-SKU debugging (direct-HTTP vendors only):**
+```bash
+uv run aichemy-price lookup fluorochem F765353-1G
+uv run aichemy-price lookup molbase 50-78-2 --json
+```
+
+`lookup` supports the four direct-HTTP vendor classes: `fluorochem`, `molbase`,
+`tocris`, `medchemexpress`.
+
+**Try every vendor through the full default chain:**
+```bash
+uv run aichemy-price chain F765353-1G
+```
+
+`chain` walks direct-HTTP vendors plus the L3 Browserbase Fetch and Browser API
+parser registries, so it also exercises ChemCruz (via Fetch) and Enamine (via
+Browser API). `BROWSERBASE_API_KEY` must be set for the L3 paths to do
+anything; otherwise they no-op.
+
+**InChIKey -> price (offline JOIN + scrape):**
+```bash
+uv run aichemy-price resolve BSYNRYMUTXBXSQ-UHFFFAOYSA-N \
+    --catalog-dir data/raw/pubchem_substance/
+```
+
+**Use as an AIchemy backend:**
+```yaml
+# configs/default.yaml
+prices:
+  backend: aichemy_pricing
+  aichemy_pricing:
+    catalog_dir: data/raw/pubchem_substance
+    cache_path: data/interim/aichemy_pricing_cache.sqlite
+```
+
+The implementation plan and verification trail live at:
+- `docs/superpowers/plans/2026-04-25-aichemy-pricing-package.md` (master)
+- `docs/superpowers/plans/2026-04-25-aichemy-pricing-{A,B,C,D,E,F}-*.md` (sub-plans)
+- `experiments/chem-pricing-verification/VERIFICATION.md` (claim verdicts)
+
+Vendors covered: Fluorochem, Molbase, Tocris, MedChemExpress (direct HTTP);
+ChemCruz (via Browserbase Fetch); Enamine (via Browserbase Browser API).
+Cayman / Sigma / Tocris-via-browser parsers exist on disk but are not yet
+registered — see `browserbase/parsers/__init__.py` and
+`browser_parsers/__init__.py` to enable.
+
+Excluded: Apollo Scientific (CLAIM-11 FALSIFIED), Sigma-Aldrich + TCI (Akamai
+proxy requirement, deferred), BLDpharm (CLAIM-16 — URL TBD).

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -26,8 +26,14 @@ yields:
   enzymatic_prior_range: [0.85, 0.95]
 
 prices:
-  backend: chained
+  backend: chained                # stub | chained | aichemy_pricing
   chain: [curated, pubchem]
+  # When backend == "aichemy_pricing", consumes the standalone aichemy_pricing
+  # package (PubChem SDF resolver -> tiered vendor chain -> static FX -> USD/g).
+  # See docs/superpowers/plans/2026-04-25-aichemy-pricing-package.md.
+  aichemy_pricing:
+    catalog_dir: data/raw/pubchem_substance
+    cache_path: data/interim/aichemy_pricing_cache.sqlite
 
 paths:
   data_dir: data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ strict = true
 files = ["src/aichemy", "src/aichemy_pricing"]
 
 [[tool.mypy.overrides]]
-module = ["rdkit.*", "patito.*", "yaml", "synrbl", "synrbl.*", "pulp", "pulp.*", "py7zr", "equilibrator_api", "equilibrator_api.*", "joblib"]
+module = ["rdkit.*", "patito.*", "yaml", "synrbl", "synrbl.*", "pulp", "pulp.*", "py7zr", "equilibrator_api", "equilibrator_api.*", "joblib", "browserbase", "browserbase.*", "curl_cffi", "curl_cffi.*", "html2text"]
 ignore_missing_imports = true
 follow_imports = "skip"
 

--- a/src/aichemy/config.py
+++ b/src/aichemy/config.py
@@ -107,15 +107,31 @@ class ScraperConfig(BaseModel):
     backoff_base_seconds: float = 2.0
 
 
+class AichemyPricingConfig(BaseModel):
+    """Backend-specific config for the standalone `aichemy_pricing` package.
+
+    Path fields point at the offline catalog (PubChem SDF dir + a SQLite cache
+    location). Free-form sub-keys are forbidden so typos surface at load time.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    catalog_dir: Path = Field(default_factory=lambda: Path("data/raw/pubchem_substance"))
+    cache_path: Path = Field(
+        default_factory=lambda: Path("data/interim/aichemy_pricing_cache.sqlite")
+    )
+
+
 class PricesConfig(BaseModel):
     model_config = {"extra": "forbid"}
 
-    backend: Literal["stub", "chained"] = "chained"
+    backend: Literal["stub", "chained", "aichemy_pricing"] = "chained"
     chain: list[str] = Field(default_factory=lambda: ["curated", "pubchem"])
     cache_path: Path = Field(default_factory=lambda: Path("data/interim/prices_cache.sqlite"))
     cache_ttl_days: int = 30
     pubchem: PubChemConfig = Field(default_factory=PubChemConfig)
     scraper: ScraperConfig = Field(default_factory=ScraperConfig)
+    aichemy_pricing: AichemyPricingConfig = Field(default_factory=AichemyPricingConfig)
 
 
 class PathsConfig(BaseModel):

--- a/src/aichemy/preprocessing/augment/prices.py
+++ b/src/aichemy/preprocessing/augment/prices.py
@@ -356,11 +356,36 @@ def make_lookup(config: PreprocessingConfig) -> PriceLookup:
     - backend="stub" → StubPriceLookup
     - backend="chained" → CachedPriceLookup(ChainedPriceLookup(...))
       built from the `chain` list, honoring scraper enablement flags.
+    - backend="aichemy_pricing" → standalone aichemy_pricing package via
+      _InchikeyAdapter (SMILES → InChIKey → resolver → chain → USD/g).
     """
     cfg = config.prices
 
     if cfg.backend == "stub":
         return StubPriceLookup()
+
+    if cfg.backend == "aichemy_pricing":
+        from aichemy_pricing import (
+            LookupByInchikey,
+            PubChemSdfResolver,
+            build_default_chain,
+        )
+
+        catalog_dir = Path(cfg.aichemy_pricing.catalog_dir)
+        cache_path = Path(cfg.aichemy_pricing.cache_path)
+        sdf_files = sorted(
+            list(catalog_dir.glob("*.sdf")) + list(catalog_dir.glob("*.sdf.gz"))
+        )
+        if not sdf_files:
+            log.warning(
+                "aichemy_pricing backend selected but no SDFs found under %s; "
+                "falling back to StubPriceLookup",
+                catalog_dir,
+            )
+            return StubPriceLookup()
+        resolver = PubChemSdfResolver.from_files(sdf_files)
+        chain = build_default_chain(cache_path=cache_path)
+        return _InchikeyAdapter(LookupByInchikey(resolver=resolver, chain=chain))
 
     lookups: list[PriceLookup] = []
     for name in cfg.chain:
@@ -438,3 +463,95 @@ def augment_prices(
         .map_elements(lambda s: prices.get(s), return_dtype=pl.Float64)
         .alias("price_per_gram"),
     )
+
+
+# ---------- aichemy_pricing adapter -----------------------------------------
+#
+# Bridges the standalone aichemy_pricing package (InChIKey -> PriceQuote with
+# native currency + pack size) onto AIchemy's PriceLookup protocol (SMILES ->
+# USD/g float). Static FX table; refresh quarterly or wire a live FX feed.
+
+import datetime as _dt  # local alias to avoid leaking 'date' into the module ns
+
+_FX_AS_OF: _dt.date = _dt.date(2026, 4, 25)
+_FX_MAX_AGE = _dt.timedelta(days=120)
+
+# USD per 1 unit of the foreign currency. Source: ECB reference rates on
+# _FX_AS_OF. MUST cover every member of `aichemy_pricing.types.Currency` —
+# the integration test asserts coverage via typing.get_args(Currency).
+_FX_TO_USD_AS_OF_2026_04_25: dict[str, float] = {
+    "USD": 1.000,
+    "GBP": 1.330,    # 1 GBP = 1.33 USD
+    "EUR": 1.090,    # 1 EUR = 1.09 USD
+    "CNY": 0.138,    # 1 CNY = 0.138 USD
+    "JPY": 0.0064,   # 1 JPY = 0.0064 USD
+    "SEK": 0.094,    # 1 SEK = 0.094 USD
+}
+
+
+def _check_fx_freshness() -> None:
+    """Emit one warning at module-import when the FX table is older than the
+    threshold. Without this, prices silently compound drift over months —
+    CNY in particular moves 5–10% intra-year. The 30-day cache TTL means a
+    stale rate is reused for every quote captured during the cache window."""
+    age = _dt.date.today() - _FX_AS_OF
+    if age > _FX_MAX_AGE:
+        log.warning(
+            "aichemy_pricing FX table is %d days old (as-of %s, max-age %d "
+            "days). Refresh ECB reference rates and bump _FX_AS_OF, or wire "
+            "a live FX feed.",
+            age.days,
+            _FX_AS_OF.isoformat(),
+            _FX_MAX_AGE.days,
+        )
+
+
+_check_fx_freshness()
+
+
+class _InchikeyAdapter:
+    """Wrap an `aichemy_pricing.LookupByInchikey` so it satisfies AIchemy's
+    PriceLookup protocol (SMILES -> USD/g float).
+
+    Per call:
+      1. SMILES -> InChIKey via RDKit (lazy import; only when this backend
+         is selected).
+      2. Delegate to LookupByInchikey -> PriceQuote | None.
+      3. Convert price_per_gram_native -> USD via static FX table.
+      4. Return float, or None on any miss.
+    """
+
+    def __init__(
+        self,
+        inner: object,  # aichemy_pricing.LookupByInchikey — typed loosely so
+                        # this module imports cleanly without the pricing extra.
+        fx_to_usd: dict[str, float] | None = None,
+    ) -> None:
+        self._inner = inner
+        self._fx = fx_to_usd or _FX_TO_USD_AS_OF_2026_04_25
+
+    def lookup(self, smiles: str) -> float | None:
+        from rdkit import Chem  # lazy import (only when this backend is used)
+
+        mol = Chem.MolFromSmiles(smiles)
+        if mol is None:
+            return None
+        try:
+            inchikey = Chem.MolToInchiKey(mol)
+        except Exception as exc:  # InChI lib raises on radicals / odd valences
+            log.warning("MolToInchiKey raised on %r: %s", smiles, exc)
+            return None
+        if not inchikey:
+            return None
+        quote = self._inner.lookup(inchikey)  # type: ignore[attr-defined]
+        if quote is None:
+            return None
+        rate = self._fx.get(quote.currency)
+        if rate is None:
+            log.warning(
+                "aichemy_pricing returned %s; no FX rate for %s — dropping quote",
+                quote,
+                quote.currency,
+            )
+            return None
+        return quote.price_per_gram_native * rate

--- a/src/aichemy/preprocessing/augment/prices.py
+++ b/src/aichemy/preprocessing/augment/prices.py
@@ -16,6 +16,7 @@ Real price scraping requires both `backend="chained"` AND
 
 from __future__ import annotations
 
+import datetime as _dt
 import json
 import logging
 import sqlite3
@@ -373,9 +374,7 @@ def make_lookup(config: PreprocessingConfig) -> PriceLookup:
 
         catalog_dir = Path(cfg.aichemy_pricing.catalog_dir)
         cache_path = Path(cfg.aichemy_pricing.cache_path)
-        sdf_files = sorted(
-            list(catalog_dir.glob("*.sdf")) + list(catalog_dir.glob("*.sdf.gz"))
-        )
+        sdf_files = sorted(list(catalog_dir.glob("*.sdf")) + list(catalog_dir.glob("*.sdf.gz")))
         if not sdf_files:
             log.warning(
                 "aichemy_pricing backend selected but no SDFs found under %s; "
@@ -384,8 +383,8 @@ def make_lookup(config: PreprocessingConfig) -> PriceLookup:
             )
             return StubPriceLookup()
         resolver = PubChemSdfResolver.from_files(sdf_files)
-        chain = build_default_chain(cache_path=cache_path)
-        return _InchikeyAdapter(LookupByInchikey(resolver=resolver, chain=chain))
+        pricing_chain = build_default_chain(cache_path=cache_path)
+        return _InchikeyAdapter(LookupByInchikey(resolver=resolver, chain=pricing_chain))
 
     lookups: list[PriceLookup] = []
     for name in cfg.chain:
@@ -471,8 +470,6 @@ def augment_prices(
 # native currency + pack size) onto AIchemy's PriceLookup protocol (SMILES ->
 # USD/g float). Static FX table; refresh quarterly or wire a live FX feed.
 
-import datetime as _dt  # local alias to avoid leaking 'date' into the module ns
-
 _FX_AS_OF: _dt.date = _dt.date(2026, 4, 25)
 _FX_MAX_AGE = _dt.timedelta(days=120)
 
@@ -481,11 +478,11 @@ _FX_MAX_AGE = _dt.timedelta(days=120)
 # the integration test asserts coverage via typing.get_args(Currency).
 _FX_TO_USD_AS_OF_2026_04_25: dict[str, float] = {
     "USD": 1.000,
-    "GBP": 1.330,    # 1 GBP = 1.33 USD
-    "EUR": 1.090,    # 1 EUR = 1.09 USD
-    "CNY": 0.138,    # 1 CNY = 0.138 USD
-    "JPY": 0.0064,   # 1 JPY = 0.0064 USD
-    "SEK": 0.094,    # 1 SEK = 0.094 USD
+    "GBP": 1.330,  # 1 GBP = 1.33 USD
+    "EUR": 1.090,  # 1 EUR = 1.09 USD
+    "CNY": 0.138,  # 1 CNY = 0.138 USD
+    "JPY": 0.0064,  # 1 JPY = 0.0064 USD
+    "SEK": 0.094,  # 1 SEK = 0.094 USD
 }
 
 
@@ -524,7 +521,7 @@ class _InchikeyAdapter:
     def __init__(
         self,
         inner: object,  # aichemy_pricing.LookupByInchikey — typed loosely so
-                        # this module imports cleanly without the pricing extra.
+        # this module imports cleanly without the pricing extra.
         fx_to_usd: dict[str, float] | None = None,
     ) -> None:
         self._inner = inner
@@ -537,7 +534,7 @@ class _InchikeyAdapter:
         if mol is None:
             return None
         try:
-            inchikey = Chem.MolToInchiKey(mol)
+            inchikey = Chem.MolToInchiKey(mol)  # type: ignore[no-untyped-call]
         except Exception as exc:  # InChI lib raises on radicals / odd valences
             log.warning("MolToInchiKey raised on %r: %s", smiles, exc)
             return None
@@ -554,4 +551,4 @@ class _InchikeyAdapter:
                 quote.currency,
             )
             return None
-        return quote.price_per_gram_native * rate
+        return float(quote.price_per_gram_native * rate)

--- a/src/aichemy_pricing/__init__.py
+++ b/src/aichemy_pricing/__init__.py
@@ -26,6 +26,7 @@ Enamine, Cayman Chemical, Santa Cruz / ChemCruz, and Sigma are reachable
 via the Browserbase L3 layer (Fetch for SSR, Browser API for SPAs); they
 are not standalone vendor classes.
 """
+
 from __future__ import annotations
 
 import logging
@@ -51,40 +52,40 @@ from aichemy_pricing.vendors.molbase import MolbaseVendor
 from aichemy_pricing.vendors.tocris import TocrisVendor
 
 __all__ = [
-    "__version__",
-    "Currency",
-    "PriceQuote",
-    "VendorRef",
-    "ResolverHit",
-    "PriceLookup",
-    "VendorResolver",
-    "ChainedPriceLookup",
-    "CachedPriceLookup",
-    "TokenBucket",
-    "make_plain_client",
-    "make_cf_client",
-    "PubChemSdfResolver",
-    "EnamineSdfResolver",
-    "ZincTrancheResolver",
-    "FluorochemVendor",
-    "MolbaseVendor",
-    "TocrisVendor",
-    "MedChemExpressVendor",
-    "BrowserbaseFetchLookup",
-    "BrowserbaseBrowserLookup",
-    "LookupByInchikey",
-    "build_default_chain",
     "_DEFAULT_VENDOR_CLASSES",  # mutable for tests; underscore = unstable
+    "BrowserbaseBrowserLookup",
+    "BrowserbaseFetchLookup",
+    "CachedPriceLookup",
+    "ChainedPriceLookup",
+    "Currency",
+    "EnamineSdfResolver",
+    "FluorochemVendor",
+    "LookupByInchikey",
+    "MedChemExpressVendor",
+    "MolbaseVendor",
+    "PriceLookup",
+    "PriceQuote",
+    "PubChemSdfResolver",
+    "ResolverHit",
+    "TocrisVendor",
+    "TokenBucket",
+    "VendorRef",
+    "VendorResolver",
+    "ZincTrancheResolver",
+    "__version__",
+    "build_default_chain",
+    "make_cf_client",
+    "make_plain_client",
 ]
 
 
 # Direct-HTTP vendor classes only. Enamine/Cayman/ChemCruz/Sigma reach the
 # chain through the L3 Browserbase layers appended below.
 _DEFAULT_VENDOR_CLASSES: list[type] = [
-    FluorochemVendor,        # L1 — Azure-blob JSON, no auth
-    TocrisVendor,            # L1 — SSR HTML, anonymous USD prices
-    MolbaseVendor,           # L1 — SSR HTML, mostly Chinese suppliers
-    MedChemExpressVendor,    # L2 — curl_cffi for Cloudflare
+    FluorochemVendor,  # L1 — Azure-blob JSON, no auth
+    TocrisVendor,  # L1 — SSR HTML, anonymous USD prices
+    MolbaseVendor,  # L1 — SSR HTML, mostly Chinese suppliers
+    MedChemExpressVendor,  # L2 — curl_cffi for Cloudflare
 ]
 
 
@@ -110,13 +111,9 @@ def build_default_chain(cache_path: Path | str) -> CachedPriceLookup:
         try:
             members.append(cls())
         except NotImplementedError as exc:
-            log.warning(
-                "build_default_chain: skipping %s — %s", cls.__name__, exc
-            )
+            log.warning("build_default_chain: skipping %s — %s", cls.__name__, exc)
     # L3a — Browserbase Fetch (SSR HTML; chemcruz parser registered today).
     members.append(BrowserbaseFetchLookup())
     # L3b — Browserbase Browser API (JS-rendered SPAs; enamine registered today).
     members.append(BrowserbaseBrowserLookup())
-    return CachedPriceLookup(
-        ChainedPriceLookup(members), db_path=cache_path, ttl_days=30
-    )
+    return CachedPriceLookup(ChainedPriceLookup(members), db_path=cache_path, ttl_days=30)

--- a/src/aichemy_pricing/__init__.py
+++ b/src/aichemy_pricing/__init__.py
@@ -1,9 +1,122 @@
 """aichemy-pricing — chemical-vendor price resolution.
 
-Public API is populated incrementally across sub-plans A–E. See
-`docs/superpowers/plans/2026-04-25-aichemy-pricing-package.md` for the parent plan.
+Standalone package: zero imports from `aichemy.*`. Installable + testable
+on its own (`uv sync --extra pricing`; `pytest src/aichemy_pricing/tests/`).
+
+Public API:
+    PriceQuote, VendorRef, ResolverHit, Currency  # types
+    PriceLookup, VendorResolver                   # protocols
+    ChainedPriceLookup, CachedPriceLookup         # composition
+    TokenBucket                                   # rate limit primitive
+    make_plain_client, make_cf_client             # HTTP factories
+    PubChemSdfResolver, EnamineSdfResolver,
+        ZincTrancheResolver                       # offline resolvers
+    FluorochemVendor, MolbaseVendor, TocrisVendor,
+        MedChemExpressVendor                      # direct-HTTP vendors
+    BrowserbaseFetchLookup, BrowserbaseBrowserLookup  # L3 (SSR + SPA)
+    LookupByInchikey                              # resolver -> chain adapter
+    build_default_chain(cache_path)               # opinionated factory
+
+Excluded by design:
+ - Apollo Scientific (CLAIM-11 — FALSIFIED)
+ - Sigma-Aldrich, TCI Chemicals (Akamai requires residential proxies)
+ - BLDpharm (CLAIM-16 — URL pattern not yet discovered)
+
+Enamine, Cayman Chemical, Santa Cruz / ChemCruz, and Sigma are reachable
+via the Browserbase L3 layer (Fetch for SSR, Browser API for SPAs); they
+are not standalone vendor classes.
 """
+from __future__ import annotations
+
+import logging
+from pathlib import Path
 
 from aichemy_pricing._version import __version__
+from aichemy_pricing.browserbase import (
+    BrowserbaseBrowserLookup,
+    BrowserbaseFetchLookup,
+)
+from aichemy_pricing.chain import CachedPriceLookup, ChainedPriceLookup
+from aichemy_pricing.http import make_cf_client, make_plain_client
+from aichemy_pricing.lookup_by_inchikey import LookupByInchikey
+from aichemy_pricing.protocol import PriceLookup, VendorResolver
+from aichemy_pricing.ratelimit import TokenBucket
+from aichemy_pricing.resolvers.enamine_sdf import EnamineSdfResolver
+from aichemy_pricing.resolvers.pubchem_sdf import PubChemSdfResolver
+from aichemy_pricing.resolvers.zinc_tranches import ZincTrancheResolver
+from aichemy_pricing.types import Currency, PriceQuote, ResolverHit, VendorRef
+from aichemy_pricing.vendors.fluorochem import FluorochemVendor
+from aichemy_pricing.vendors.medchemexpress import MedChemExpressVendor
+from aichemy_pricing.vendors.molbase import MolbaseVendor
+from aichemy_pricing.vendors.tocris import TocrisVendor
 
-__all__ = ["__version__"]
+__all__ = [
+    "__version__",
+    "Currency",
+    "PriceQuote",
+    "VendorRef",
+    "ResolverHit",
+    "PriceLookup",
+    "VendorResolver",
+    "ChainedPriceLookup",
+    "CachedPriceLookup",
+    "TokenBucket",
+    "make_plain_client",
+    "make_cf_client",
+    "PubChemSdfResolver",
+    "EnamineSdfResolver",
+    "ZincTrancheResolver",
+    "FluorochemVendor",
+    "MolbaseVendor",
+    "TocrisVendor",
+    "MedChemExpressVendor",
+    "BrowserbaseFetchLookup",
+    "BrowserbaseBrowserLookup",
+    "LookupByInchikey",
+    "build_default_chain",
+    "_DEFAULT_VENDOR_CLASSES",  # mutable for tests; underscore = unstable
+]
+
+
+# Direct-HTTP vendor classes only. Enamine/Cayman/ChemCruz/Sigma reach the
+# chain through the L3 Browserbase layers appended below.
+_DEFAULT_VENDOR_CLASSES: list[type] = [
+    FluorochemVendor,        # L1 — Azure-blob JSON, no auth
+    TocrisVendor,            # L1 — SSR HTML, anonymous USD prices
+    MolbaseVendor,           # L1 — SSR HTML, mostly Chinese suppliers
+    MedChemExpressVendor,    # L2 — curl_cffi for Cloudflare
+]
+
+
+def build_default_chain(cache_path: Path | str) -> CachedPriceLookup:
+    """Standard tiered vendor chain: direct-HTTP vendors first, then L3
+    Browserbase layers, all wrapped in a SQLite cache.
+
+    Order rationale: cheapest things fire first. L1 plain HTTPS (~100ms);
+    L2 curl_cffi for Cloudflare (~1s); L3a Browserbase Fetch ($0.001/call,
+    SSR-only); L3b Browserbase Browser API ($0.0003/call but ~10s of
+    session time, JS-rendered SPAs).
+
+    Placeholder-aware construction (Revision 16): if any vendor's
+    __init__ raises NotImplementedError (used today as a fail-loud signal
+    that an out-of-band discovery step is unfinished), we log a warning
+    and skip that vendor instead of aborting the whole chain. The L3
+    Browserbase lookups are appended unconditionally — both no-op when
+    BROWSERBASE_API_KEY is unset, so they're always safe to include.
+    """
+    log = logging.getLogger(__name__)
+    members: list[PriceLookup] = []
+    for cls in _DEFAULT_VENDOR_CLASSES:
+        try:
+            members.append(cls())
+        except NotImplementedError as exc:
+            log.warning(
+                "build_default_chain: skipping %s — %s", cls.__name__, exc
+            )
+    # L3a — Browserbase Fetch (SSR HTML; chemcruz parser registered today).
+    members.append(BrowserbaseFetchLookup())
+    # L3b — Browserbase Browser API (JS-rendered SPAs; enamine registered today).
+    members.append(BrowserbaseBrowserLookup())
+    return CachedPriceLookup(
+        ChainedPriceLookup(members), db_path=cache_path, ttl_days=30
+    )

--- a/src/aichemy_pricing/browserbase/client.py
+++ b/src/aichemy_pricing/browserbase/client.py
@@ -43,7 +43,7 @@ def _html_to_markdown(html: str) -> str:
     h.body_width = 0
     h.ignore_images = True
     h.ignore_emphasis = True
-    return h.handle(html)
+    return str(h.handle(html))
 
 
 class BrowserbaseClient:

--- a/src/aichemy_pricing/cli.py
+++ b/src/aichemy_pricing/cli.py
@@ -15,6 +15,7 @@ classes (fluorochem, molbase, tocris, medchemexpress). For Enamine /
 Cayman / ChemCruz / Sigma, use `chain` or `resolve` — those vendors are
 reached via the L3 Browserbase layers (Fetch for SSR, Browser API for SPAs).
 """
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -38,6 +39,16 @@ from aichemy_pricing.browserbase.parsers import REGISTRY as _FETCH_REGISTRY
 from aichemy_pricing.lookup_by_inchikey import LookupByInchikey
 
 app = typer.Typer(help="aichemy-pricing CLI")
+
+# Module-level Option singletons — keeps typer.Option calls out of function
+# defaults (B008) without sacrificing the descriptive help text.
+_CHAIN_CACHE_OPT = typer.Option(
+    Path(".aichemy_pricing_cache_chain.sqlite"),
+    "--cache",
+    help="SQLite cache path (re-used across invocations to save calls)",
+)
+_CATALOG_DIR_OPT = typer.Option(..., "--catalog-dir", help="Directory with PubChem SDFs")
+_RESOLVE_CACHE_OPT = typer.Option(Path(".aichemy_pricing_cache.sqlite"), "--cache")
 
 # Map vendor short-name -> direct-HTTP vendor class. Mutable for tests via
 # monkeypatch. Enamine / Cayman / ChemCruz / Sigma are *not* here — they
@@ -73,10 +84,7 @@ def main(
 def lookup(
     vendor: str = typer.Argument(
         ...,
-        help=(
-            "Vendor short-name; one of: fluorochem, molbase, tocris, "
-            "medchemexpress"
-        ),
+        help=("Vendor short-name; one of: fluorochem, molbase, tocris, medchemexpress"),
     ),
     sku: str = typer.Argument(..., help="Vendor SKU"),
     as_json: bool = typer.Option(False, "--json", help="Emit JSON"),
@@ -94,9 +102,7 @@ def lookup(
         # Discovery placeholder unfilled (Revision 27 — symmetric with the
         # chain factory's placeholder skip). Surface a clean exit rather
         # than a bare Python traceback.
-        typer.echo(
-            f"{vendor}: discovery placeholder unfilled — {exc}", err=True
-        )
+        typer.echo(f"{vendor}: discovery placeholder unfilled — {exc}", err=True)
         raise typer.Exit(2) from exc
     quote = v.lookup(VendorRef(vendor=vendor, sku=sku))
     if quote is None:
@@ -113,11 +119,7 @@ def chain(
     sku: str = typer.Argument(
         ..., help="SKU to try across every known vendor in the default chain"
     ),
-    cache_path: Path = typer.Option(
-        Path(".aichemy_pricing_cache_chain.sqlite"),
-        "--cache",
-        help="SQLite cache path (re-used across invocations to save calls)",
-    ),
+    cache_path: Path = _CHAIN_CACHE_OPT,
 ) -> None:
     """Try every known vendor name on a SKU through the full default chain.
 
@@ -130,9 +132,7 @@ def chain(
     """
     pipeline = build_default_chain(cache_path=cache_path)
     candidates = (
-        list(_VENDORS.keys())
-        + list(_FETCH_REGISTRY.keys())
-        + list(_BROWSER_REGISTRY.keys())
+        list(_VENDORS.keys()) + list(_FETCH_REGISTRY.keys()) + list(_BROWSER_REGISTRY.keys())
     )
     seen: set[str] = set()
     for name in candidates:
@@ -142,7 +142,7 @@ def chain(
         ref = VendorRef(vendor=name, sku=sku)
         try:
             q = pipeline.lookup(ref)
-        except Exception as exc:  # noqa: BLE001 — debug walk, surface and continue
+        except Exception as exc:  # debug walk; one parser bug shouldn't abort the rest
             typer.echo(f"{name}: error — {exc}", err=True)
             continue
         if q is not None:
@@ -155,17 +155,11 @@ def chain(
 @app.command()
 def resolve(
     inchikey: str = typer.Argument(..., help="Standard InChIKey (27 chars)"),
-    catalog_dir: Path = typer.Option(
-        ..., "--catalog-dir", help="Directory with PubChem SDFs"
-    ),
-    cache_path: Path = typer.Option(
-        Path(".aichemy_pricing_cache.sqlite"), "--cache"
-    ),
+    catalog_dir: Path = _CATALOG_DIR_OPT,
+    cache_path: Path = _RESOLVE_CACHE_OPT,
 ) -> None:
     """Walk a PubChem SDF catalog -> default chain to price an InChIKey."""
-    sdf_files = sorted(
-        list(catalog_dir.glob("*.sdf")) + list(catalog_dir.glob("*.sdf.gz"))
-    )
+    sdf_files = sorted(list(catalog_dir.glob("*.sdf")) + list(catalog_dir.glob("*.sdf.gz")))
     if not sdf_files:
         typer.echo(f"no .sdf or .sdf.gz files in {catalog_dir}", err=True)
         raise typer.Exit(2)

--- a/src/aichemy_pricing/cli.py
+++ b/src/aichemy_pricing/cli.py
@@ -1,0 +1,183 @@
+"""`aichemy-price` — CLI for single-SKU and end-to-end price lookups.
+
+Usage:
+    aichemy-price --version
+    aichemy-price lookup fluorochem F765353-1G
+    aichemy-price lookup molbase 50-78-2 --json
+    aichemy-price chain F765353-1G                         # walks every known
+                                                            # vendor name through
+                                                            # the full default chain
+    aichemy-price resolve BSYNRYMUTXBXSQ-UHFFFAOYSA-N \\
+        --catalog-dir data/raw/pubchem_substance/
+
+Vendor short-names supported by `lookup` are the four with direct-HTTP
+classes (fluorochem, molbase, tocris, medchemexpress). For Enamine /
+Cayman / ChemCruz / Sigma, use `chain` or `resolve` — those vendors are
+reached via the L3 Browserbase layers (Fetch for SSR, Browser API for SPAs).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from aichemy_pricing import (
+    FluorochemVendor,
+    MedChemExpressVendor,
+    MolbaseVendor,
+    PubChemSdfResolver,
+    TocrisVendor,
+    VendorRef,
+    __version__,
+    build_default_chain,
+)
+from aichemy_pricing.browserbase.browser_parsers import (
+    REGISTRY as _BROWSER_REGISTRY,
+)
+from aichemy_pricing.browserbase.parsers import REGISTRY as _FETCH_REGISTRY
+from aichemy_pricing.lookup_by_inchikey import LookupByInchikey
+
+app = typer.Typer(help="aichemy-pricing CLI")
+
+# Map vendor short-name -> direct-HTTP vendor class. Mutable for tests via
+# monkeypatch. Enamine / Cayman / ChemCruz / Sigma are *not* here — they
+# only reach the chain via L3 Browserbase paths.
+_VENDORS: dict[str, type] = {
+    "fluorochem": FluorochemVendor,
+    "molbase": MolbaseVendor,
+    "tocris": TocrisVendor,
+    "medchemexpress": MedChemExpressVendor,
+}
+
+
+def _version_cb(value: bool) -> None:
+    if value:
+        typer.echo(__version__)
+        raise typer.Exit()
+
+
+@app.callback()
+def main(
+    version: bool = typer.Option(
+        False,
+        "--version",
+        callback=_version_cb,
+        is_eager=True,
+        help="Show version and exit",
+    ),
+) -> None:
+    """aichemy-pricing CLI."""
+
+
+@app.command()
+def lookup(
+    vendor: str = typer.Argument(
+        ...,
+        help=(
+            "Vendor short-name; one of: fluorochem, molbase, tocris, "
+            "medchemexpress"
+        ),
+    ),
+    sku: str = typer.Argument(..., help="Vendor SKU"),
+    as_json: bool = typer.Option(False, "--json", help="Emit JSON"),
+) -> None:
+    """Look up a single SKU at one direct-HTTP vendor."""
+    if vendor not in _VENDORS:
+        typer.echo(
+            f"Unknown vendor: {vendor!r}; choose from {sorted(_VENDORS)}",
+            err=True,
+        )
+        raise typer.Exit(2)
+    try:
+        v = _VENDORS[vendor]()
+    except NotImplementedError as exc:
+        # Discovery placeholder unfilled (Revision 27 — symmetric with the
+        # chain factory's placeholder skip). Surface a clean exit rather
+        # than a bare Python traceback.
+        typer.echo(
+            f"{vendor}: discovery placeholder unfilled — {exc}", err=True
+        )
+        raise typer.Exit(2) from exc
+    quote = v.lookup(VendorRef(vendor=vendor, sku=sku))
+    if quote is None:
+        typer.echo("no quote (404 / unparseable / not stocked)", err=True)
+        raise typer.Exit(1)
+    if as_json:
+        typer.echo(quote.model_dump_json(indent=2))
+    else:
+        typer.echo(f"{quote.price} {quote.currency} / {quote.pack_size_g} g")
+
+
+@app.command()
+def chain(
+    sku: str = typer.Argument(
+        ..., help="SKU to try across every known vendor in the default chain"
+    ),
+    cache_path: Path = typer.Option(
+        Path(".aichemy_pricing_cache_chain.sqlite"),
+        "--cache",
+        help="SQLite cache path (re-used across invocations to save calls)",
+    ),
+) -> None:
+    """Try every known vendor name on a SKU through the full default chain.
+
+    Walks the union of direct-HTTP vendors (`_VENDORS`), the L3 Fetch
+    parser registry, and the L3 Browser API parser registry — for each
+    candidate vendor name builds a `VendorRef(vendor=name, sku=sku)` and
+    runs it through `build_default_chain`. Prints the first hit. SKU
+    format is vendor-specific; if you don't know which vendor a chemical
+    matches, use `resolve` with an InChIKey + PubChem SDF directory.
+    """
+    pipeline = build_default_chain(cache_path=cache_path)
+    candidates = (
+        list(_VENDORS.keys())
+        + list(_FETCH_REGISTRY.keys())
+        + list(_BROWSER_REGISTRY.keys())
+    )
+    seen: set[str] = set()
+    for name in candidates:
+        if name in seen:
+            continue
+        seen.add(name)
+        ref = VendorRef(vendor=name, sku=sku)
+        try:
+            q = pipeline.lookup(ref)
+        except Exception as exc:  # noqa: BLE001 — debug walk, surface and continue
+            typer.echo(f"{name}: error — {exc}", err=True)
+            continue
+        if q is not None:
+            typer.echo(f"{q.vendor}: {q.price} {q.currency} / {q.pack_size_g} g")
+            raise typer.Exit(0)
+    typer.echo("no vendor returned a price", err=True)
+    raise typer.Exit(1)
+
+
+@app.command()
+def resolve(
+    inchikey: str = typer.Argument(..., help="Standard InChIKey (27 chars)"),
+    catalog_dir: Path = typer.Option(
+        ..., "--catalog-dir", help="Directory with PubChem SDFs"
+    ),
+    cache_path: Path = typer.Option(
+        Path(".aichemy_pricing_cache.sqlite"), "--cache"
+    ),
+) -> None:
+    """Walk a PubChem SDF catalog -> default chain to price an InChIKey."""
+    sdf_files = sorted(
+        list(catalog_dir.glob("*.sdf")) + list(catalog_dir.glob("*.sdf.gz"))
+    )
+    if not sdf_files:
+        typer.echo(f"no .sdf or .sdf.gz files in {catalog_dir}", err=True)
+        raise typer.Exit(2)
+    resolver = PubChemSdfResolver.from_files(sdf_files)
+    pipeline = build_default_chain(cache_path=cache_path)
+    adapter = LookupByInchikey(resolver=resolver, chain=pipeline)
+    quote = adapter.lookup(inchikey)
+    if quote is None:
+        typer.echo("no quote", err=True)
+        raise typer.Exit(1)
+    typer.echo(quote.model_dump_json(indent=2))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()

--- a/src/aichemy_pricing/lookup_by_inchikey.py
+++ b/src/aichemy_pricing/lookup_by_inchikey.py
@@ -7,6 +7,7 @@ Internals:
      and call chain.lookup(ref) -> PriceQuote | None
   3. return first non-None quote, or None if every hit misses.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -22,9 +23,7 @@ class LookupByInchikey:
 
     def lookup(self, inchikey: str) -> PriceQuote | None:
         for hit in self.resolver.resolve(inchikey):
-            ref = VendorRef(
-                vendor=hit.vendor, sku=hit.sku, canonical_url=hit.canonical_url
-            )
+            ref = VendorRef(vendor=hit.vendor, sku=hit.sku, canonical_url=hit.canonical_url)
             quote = self.chain.lookup(ref)
             if quote is not None:
                 return quote

--- a/src/aichemy_pricing/lookup_by_inchikey.py
+++ b/src/aichemy_pricing/lookup_by_inchikey.py
@@ -1,0 +1,31 @@
+"""Adapter that composes a VendorResolver with a PriceLookup chain.
+
+Caller asks: "give me a price for this InChIKey".
+Internals:
+  1. resolver.resolve(ik) -> list[ResolverHit] (in vendor priority order)
+  2. for each hit, build VendorRef(vendor=hit.vendor, sku=hit.sku, ...)
+     and call chain.lookup(ref) -> PriceQuote | None
+  3. return first non-None quote, or None if every hit misses.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from aichemy_pricing.protocol import PriceLookup, VendorResolver
+from aichemy_pricing.types import PriceQuote, VendorRef
+
+
+@dataclass
+class LookupByInchikey:
+    resolver: VendorResolver
+    chain: PriceLookup
+
+    def lookup(self, inchikey: str) -> PriceQuote | None:
+        for hit in self.resolver.resolve(inchikey):
+            ref = VendorRef(
+                vendor=hit.vendor, sku=hit.sku, canonical_url=hit.canonical_url
+            )
+            quote = self.chain.lookup(ref)
+            if quote is not None:
+                return quote
+        return None

--- a/src/aichemy_pricing/tests/test_build_default_chain.py
+++ b/src/aichemy_pricing/tests/test_build_default_chain.py
@@ -1,0 +1,63 @@
+"""Unit tests for build_default_chain."""
+from __future__ import annotations
+
+import logging
+
+from aichemy_pricing import (
+    CachedPriceLookup,
+    ChainedPriceLookup,
+    build_default_chain,
+)
+
+
+def test_build_default_chain_returns_cached_chain(tmp_path) -> None:
+    chain = build_default_chain(cache_path=tmp_path / "c.sqlite")
+    assert isinstance(chain, CachedPriceLookup)
+    assert isinstance(chain.inner, ChainedPriceLookup)
+
+
+def test_build_default_chain_omits_excluded_vendors_and_includes_required(
+    tmp_path,
+) -> None:
+    chain = build_default_chain(cache_path=tmp_path / "c.sqlite")
+    vendor_names = {m.name for m in chain.inner.members}
+    excluded = {"apollo", "sigma", "sigma-aldrich", "tci", "bld", "bldpharm"}
+    assert vendor_names.isdisjoint(excluded)
+    # The 4 direct-HTTP vendor classes plus the two L3 Browserbase layers
+    # must always be present. ChemCruz/Enamine reach the chain *through*
+    # those L3 layers (parser registries), they are not chain members.
+    required = {
+        "fluorochem",
+        "tocris",
+        "molbase",
+        "medchemexpress",
+        "browserbase_fetch",
+        "browserbase_browser",
+    }
+    assert required.issubset(vendor_names)
+
+
+def test_build_default_chain_skips_placeholder_vendors_gracefully(
+    tmp_path, monkeypatch, caplog
+) -> None:
+    """If a vendor's __init__ raises NotImplementedError (the placeholder
+    fail-loud guard), the chain factory must catch it, log a warning, and
+    continue — not crash. Mirrors the production behavior where
+    augment_prices keeps running even with one undiscovered vendor."""
+    import aichemy_pricing as pkg
+
+    class _Boom:
+        name = "boom"
+
+        def __init__(self) -> None:
+            raise NotImplementedError("simulated discovery placeholder")
+
+    monkeypatch.setattr(
+        pkg, "_DEFAULT_VENDOR_CLASSES", [_Boom, *pkg._DEFAULT_VENDOR_CLASSES]
+    )
+    with caplog.at_level(logging.WARNING):
+        chain = build_default_chain(cache_path=tmp_path / "c.sqlite")
+    assert "boom" not in {m.name for m in chain.inner.members}
+    assert any(
+        "simulated discovery placeholder" in r.message for r in caplog.records
+    )

--- a/src/aichemy_pricing/tests/test_build_default_chain.py
+++ b/src/aichemy_pricing/tests/test_build_default_chain.py
@@ -1,4 +1,5 @@
 """Unit tests for build_default_chain."""
+
 from __future__ import annotations
 
 import logging
@@ -20,6 +21,7 @@ def test_build_default_chain_omits_excluded_vendors_and_includes_required(
     tmp_path,
 ) -> None:
     chain = build_default_chain(cache_path=tmp_path / "c.sqlite")
+    assert isinstance(chain.inner, ChainedPriceLookup)
     vendor_names = {m.name for m in chain.inner.members}
     excluded = {"apollo", "sigma", "sigma-aldrich", "tci", "bld", "bldpharm"}
     assert vendor_names.isdisjoint(excluded)
@@ -52,12 +54,9 @@ def test_build_default_chain_skips_placeholder_vendors_gracefully(
         def __init__(self) -> None:
             raise NotImplementedError("simulated discovery placeholder")
 
-    monkeypatch.setattr(
-        pkg, "_DEFAULT_VENDOR_CLASSES", [_Boom, *pkg._DEFAULT_VENDOR_CLASSES]
-    )
+    monkeypatch.setattr(pkg, "_DEFAULT_VENDOR_CLASSES", [_Boom, *pkg._DEFAULT_VENDOR_CLASSES])
     with caplog.at_level(logging.WARNING):
         chain = build_default_chain(cache_path=tmp_path / "c.sqlite")
+    assert isinstance(chain.inner, ChainedPriceLookup)
     assert "boom" not in {m.name for m in chain.inner.members}
-    assert any(
-        "simulated discovery placeholder" in r.message for r in caplog.records
-    )
+    assert any("simulated discovery placeholder" in r.message for r in caplog.records)

--- a/src/aichemy_pricing/tests/test_cli.py
+++ b/src/aichemy_pricing/tests/test_cli.py
@@ -1,0 +1,116 @@
+"""Unit tests for `aichemy-price` CLI."""
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+from typer.testing import CliRunner
+
+from aichemy_pricing import cli as cli_module
+from aichemy_pricing.cli import app
+from aichemy_pricing.types import PriceQuote, VendorRef
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def test_cli_version_flag(runner: CliRunner) -> None:
+    res = runner.invoke(app, ["--version"])
+    assert res.exit_code == 0
+    from aichemy_pricing import __version__
+
+    assert __version__ in res.stdout
+
+
+def test_cli_lookup_unknown_vendor_returns_2(runner: CliRunner) -> None:
+    res = runner.invoke(app, ["lookup", "no-such-vendor", "X"])
+    assert res.exit_code == 2
+    assert "Unknown vendor" in (res.stdout + (res.stderr or ""))
+
+
+def test_cli_lookup_calls_vendor(runner: CliRunner, monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    quote = PriceQuote(
+        vendor="fluorochem",
+        sku="F765353-1G",
+        price=230.0,
+        currency="GBP",
+        pack_size_g=1.0,
+        fetched_at=datetime(2026, 4, 25, tzinfo=UTC),
+    )
+
+    class FakeVendor:
+        name = "fluorochem"
+
+        def lookup(self, ref: VendorRef) -> PriceQuote:
+            captured["ref"] = ref
+            return quote
+
+    monkeypatch.setitem(cli_module._VENDORS, "fluorochem", FakeVendor)
+    res = runner.invoke(app, ["lookup", "fluorochem", "F765353-1G"])
+    assert res.exit_code == 0
+    assert "230" in res.stdout and "GBP" in res.stdout
+    assert isinstance(captured["ref"], VendorRef)
+
+
+def test_cli_lookup_json_flag_dumps_pricequote(
+    runner: CliRunner, monkeypatch
+) -> None:
+    quote = PriceQuote(
+        vendor="fluorochem",
+        sku="F1-1G",
+        price=1.0,
+        currency="USD",
+        pack_size_g=1.0,
+        fetched_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+
+    class FakeVendor:
+        name = "fluorochem"
+
+        def lookup(self, ref: VendorRef) -> PriceQuote:
+            return quote
+
+    monkeypatch.setitem(cli_module._VENDORS, "fluorochem", FakeVendor)
+    res = runner.invoke(app, ["lookup", "fluorochem", "F1-1G", "--json"])
+    assert res.exit_code == 0
+    parsed = json.loads(res.stdout)
+    assert parsed["price"] == 1.0
+    assert parsed["currency"] == "USD"
+
+
+def test_cli_lookup_returns_1_when_no_quote(
+    runner: CliRunner, monkeypatch
+) -> None:
+    class MissVendor:
+        name = "fluorochem"
+
+        def lookup(self, ref: VendorRef) -> None:
+            return None
+
+    monkeypatch.setitem(cli_module._VENDORS, "fluorochem", MissVendor)
+    res = runner.invoke(app, ["lookup", "fluorochem", "x"])
+    assert res.exit_code == 1
+
+
+def test_cli_lookup_placeholder_vendor_returns_2(
+    runner: CliRunner, monkeypatch
+) -> None:
+    """Vendors with unfilled discovery placeholders raise NotImplementedError
+    from __init__ (fail-loud guard). The CLI must surface a clean
+    typer.Exit(2), not a bare Python traceback."""
+
+    class _Placeholder:
+        name = "fluorochem"
+
+        def __init__(self) -> None:
+            raise NotImplementedError("_API_URL not yet discovered")
+
+    monkeypatch.setitem(cli_module._VENDORS, "fluorochem", _Placeholder)
+    res = runner.invoke(app, ["lookup", "fluorochem", "X"])
+    assert res.exit_code == 2
+    out = (res.stdout + (res.stderr or "")).lower()
+    assert "discovery placeholder" in out

--- a/src/aichemy_pricing/tests/test_cli.py
+++ b/src/aichemy_pricing/tests/test_cli.py
@@ -1,4 +1,5 @@
 """Unit tests for `aichemy-price` CLI."""
+
 from __future__ import annotations
 
 import json
@@ -56,9 +57,7 @@ def test_cli_lookup_calls_vendor(runner: CliRunner, monkeypatch) -> None:
     assert isinstance(captured["ref"], VendorRef)
 
 
-def test_cli_lookup_json_flag_dumps_pricequote(
-    runner: CliRunner, monkeypatch
-) -> None:
+def test_cli_lookup_json_flag_dumps_pricequote(runner: CliRunner, monkeypatch) -> None:
     quote = PriceQuote(
         vendor="fluorochem",
         sku="F1-1G",
@@ -82,9 +81,7 @@ def test_cli_lookup_json_flag_dumps_pricequote(
     assert parsed["currency"] == "USD"
 
 
-def test_cli_lookup_returns_1_when_no_quote(
-    runner: CliRunner, monkeypatch
-) -> None:
+def test_cli_lookup_returns_1_when_no_quote(runner: CliRunner, monkeypatch) -> None:
     class MissVendor:
         name = "fluorochem"
 
@@ -96,9 +93,7 @@ def test_cli_lookup_returns_1_when_no_quote(
     assert res.exit_code == 1
 
 
-def test_cli_lookup_placeholder_vendor_returns_2(
-    runner: CliRunner, monkeypatch
-) -> None:
+def test_cli_lookup_placeholder_vendor_returns_2(runner: CliRunner, monkeypatch) -> None:
     """Vendors with unfilled discovery placeholders raise NotImplementedError
     from __init__ (fail-loud guard). The CLI must surface a clean
     typer.Exit(2), not a bare Python traceback."""

--- a/src/aichemy_pricing/tests/test_lookup_by_inchikey.py
+++ b/src/aichemy_pricing/tests/test_lookup_by_inchikey.py
@@ -1,4 +1,5 @@
 """Unit tests for LookupByInchikey adapter."""
+
 from __future__ import annotations
 
 from datetime import UTC, datetime
@@ -57,17 +58,13 @@ def test_lookup_returns_none_when_no_resolver_hits() -> None:
     resolver = _StaticResolver([])
     chain = _ConditionalChain({"enamine"})
     assert (
-        LookupByInchikey(resolver=resolver, chain=chain).lookup(
-            "BSYNRYMUTXBXSQ-UHFFFAOYSA-N"
-        )
+        LookupByInchikey(resolver=resolver, chain=chain).lookup("BSYNRYMUTXBXSQ-UHFFFAOYSA-N")
         is None
     )
 
 
 def test_lookup_returns_none_when_no_chain_member_prices_any_resolver_hit() -> None:
     ik = "BSYNRYMUTXBXSQ-UHFFFAOYSA-N"
-    resolver = _StaticResolver(
-        [ResolverHit(inchikey=ik, vendor="apollo", sku="X")]
-    )
+    resolver = _StaticResolver([ResolverHit(inchikey=ik, vendor="apollo", sku="X")])
     chain = _ConditionalChain({"enamine"})  # apollo not in chain
     assert LookupByInchikey(resolver=resolver, chain=chain).lookup(ik) is None

--- a/src/aichemy_pricing/tests/test_lookup_by_inchikey.py
+++ b/src/aichemy_pricing/tests/test_lookup_by_inchikey.py
@@ -1,0 +1,73 @@
+"""Unit tests for LookupByInchikey adapter."""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from aichemy_pricing.lookup_by_inchikey import LookupByInchikey
+from aichemy_pricing.types import PriceQuote, ResolverHit, VendorRef
+
+
+class _StaticResolver:
+    name = "static"
+
+    def __init__(self, hits: list[ResolverHit]) -> None:
+        self.hits = hits
+
+    def resolve(self, inchikey: str) -> list[ResolverHit]:
+        return [h for h in self.hits if h.inchikey == inchikey]
+
+
+class _ConditionalChain:
+    """Returns a price for any ref whose vendor is in `priced_vendors`."""
+
+    name = "chain"
+
+    def __init__(self, priced_vendors: set[str]) -> None:
+        self.priced_vendors = priced_vendors
+
+    def lookup(self, ref: VendorRef) -> PriceQuote | None:
+        if ref.vendor in self.priced_vendors:
+            return PriceQuote(
+                vendor=ref.vendor,
+                sku=ref.sku,
+                price=1.0,
+                currency="USD",
+                pack_size_g=1.0,
+                fetched_at=datetime(2026, 1, 1, tzinfo=UTC),
+            )
+        return None
+
+
+def test_lookup_returns_first_priced_vendor_per_inchikey() -> None:
+    ik = "BSYNRYMUTXBXSQ-UHFFFAOYSA-N"
+    resolver = _StaticResolver(
+        [
+            ResolverHit(inchikey=ik, vendor="apollo", sku="X"),  # not priced
+            ResolverHit(inchikey=ik, vendor="enamine", sku="EN300-1"),
+            ResolverHit(inchikey=ik, vendor="fluorochem", sku="F1-1G"),
+        ]
+    )
+    chain = _ConditionalChain({"enamine", "fluorochem"})
+    out = LookupByInchikey(resolver=resolver, chain=chain).lookup(ik)
+    assert out is not None
+    assert out.vendor == "enamine"  # first priced hit wins
+
+
+def test_lookup_returns_none_when_no_resolver_hits() -> None:
+    resolver = _StaticResolver([])
+    chain = _ConditionalChain({"enamine"})
+    assert (
+        LookupByInchikey(resolver=resolver, chain=chain).lookup(
+            "BSYNRYMUTXBXSQ-UHFFFAOYSA-N"
+        )
+        is None
+    )
+
+
+def test_lookup_returns_none_when_no_chain_member_prices_any_resolver_hit() -> None:
+    ik = "BSYNRYMUTXBXSQ-UHFFFAOYSA-N"
+    resolver = _StaticResolver(
+        [ResolverHit(inchikey=ik, vendor="apollo", sku="X")]
+    )
+    chain = _ConditionalChain({"enamine"})  # apollo not in chain
+    assert LookupByInchikey(resolver=resolver, chain=chain).lookup(ik) is None

--- a/tests/integration/test_pricing_package_integration.py
+++ b/tests/integration/test_pricing_package_integration.py
@@ -3,6 +3,7 @@
 Offline only — uses captured Fluorochem fixture bytes via httpx.Client.send
 monkeypatching. Skipped at collection time when the pricing extra is absent.
 """
+
 from __future__ import annotations
 
 import typing
@@ -33,20 +34,16 @@ def test_fx_table_covers_every_currency_literal() -> None:
     )
 
 
-def test_aichemy_pricing_chain_round_trips_fluorochem_fixture(
-    tmp_path, monkeypatch
-) -> None:
+def test_aichemy_pricing_chain_round_trips_fluorochem_fixture(tmp_path, monkeypatch) -> None:
     """Build the default chain, intercept the fluorochem URL with the
     captured fixture bytes, and confirm a round-trip PriceQuote with the
     expected currency + price."""
     from aichemy_pricing import build_default_chain
     from aichemy_pricing.types import VendorRef
 
-    fixture = Path(
-        "src/aichemy_pricing/tests/data/fluorochem_F765353.json"
-    ).read_bytes()
+    fixture = Path("src/aichemy_pricing/tests/data/fluorochem_F765353.json").read_bytes()
 
-    def mock_send(self, request, **kw):  # noqa: ARG001
+    def mock_send(self, request, **kw):
         if "fluorochem" in str(request.url):
             return httpx.Response(200, content=fixture, request=request)
         return httpx.Response(404, request=request)

--- a/tests/integration/test_pricing_package_integration.py
+++ b/tests/integration/test_pricing_package_integration.py
@@ -1,0 +1,60 @@
+"""End-to-end: AIchemy pipeline picks up aichemy_pricing as a backend.
+
+Offline only — uses captured Fluorochem fixture bytes via httpx.Client.send
+monkeypatching. Skipped at collection time when the pricing extra is absent.
+"""
+from __future__ import annotations
+
+import typing
+from pathlib import Path
+
+import httpx
+import pytest
+
+# Skip at collection time if pricing extra isn't installed.
+pytest.importorskip("aichemy_pricing")
+
+
+def test_fx_table_covers_every_currency_literal() -> None:
+    """The _InchikeyAdapter returns None when a quote arrives in a currency
+    missing from the FX table, with a warning log. That's a silent yield drop
+    waiting to happen if anyone adds a new Currency literal without also
+    extending the FX table. Lock that invariant in (Revision 10).
+    """
+    from aichemy.preprocessing.augment.prices import _FX_TO_USD_AS_OF_2026_04_25
+    from aichemy_pricing.types import Currency
+
+    declared_currencies = set(typing.get_args(Currency))
+    fx_currencies = set(_FX_TO_USD_AS_OF_2026_04_25)
+    missing = declared_currencies - fx_currencies
+    assert not missing, (
+        f"Currency literal members missing from FX table: {missing}. "
+        f"Either add an FX rate or shrink the Currency literal."
+    )
+
+
+def test_aichemy_pricing_chain_round_trips_fluorochem_fixture(
+    tmp_path, monkeypatch
+) -> None:
+    """Build the default chain, intercept the fluorochem URL with the
+    captured fixture bytes, and confirm a round-trip PriceQuote with the
+    expected currency + price."""
+    from aichemy_pricing import build_default_chain
+    from aichemy_pricing.types import VendorRef
+
+    fixture = Path(
+        "src/aichemy_pricing/tests/data/fluorochem_F765353.json"
+    ).read_bytes()
+
+    def mock_send(self, request, **kw):  # noqa: ARG001
+        if "fluorochem" in str(request.url):
+            return httpx.Response(200, content=fixture, request=request)
+        return httpx.Response(404, request=request)
+
+    monkeypatch.setattr(httpx.Client, "send", mock_send)
+
+    chain = build_default_chain(cache_path=tmp_path / "c.sqlite")
+    quote = chain.lookup(VendorRef(vendor="fluorochem", sku="F765353-1G"))
+    assert quote is not None
+    assert quote.currency == "GBP"
+    assert quote.price == 230.0

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -60,9 +60,7 @@ def test_prices_aichemy_pricing_backend_schema() -> None:
 
     cfg = PreprocessingConfig()
     assert isinstance(cfg.prices.aichemy_pricing, AichemyPricingConfig)
-    assert cfg.prices.aichemy_pricing.catalog_dir == Path(
-        "data/raw/pubchem_substance"
-    )
+    assert cfg.prices.aichemy_pricing.catalog_dir == Path("data/raw/pubchem_substance")
     assert cfg.prices.aichemy_pricing.cache_path == Path(
         "data/interim/aichemy_pricing_cache.sqlite"
     )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -51,6 +51,25 @@ def test_subconfigs_are_own_models() -> None:
     assert isinstance(PreprocessingConfig().paths, PathsConfig)
 
 
+def test_prices_aichemy_pricing_backend_schema() -> None:
+    """The widened backend Literal must accept 'aichemy_pricing', and the new
+    sub-config must default to the pubchem_substance / SQLite cache paths.
+    Without this assertion, a regression that drops either field surfaces
+    only as a CLI runtime error."""
+    from aichemy.config import AichemyPricingConfig
+
+    cfg = PreprocessingConfig()
+    assert isinstance(cfg.prices.aichemy_pricing, AichemyPricingConfig)
+    assert cfg.prices.aichemy_pricing.catalog_dir == Path(
+        "data/raw/pubchem_substance"
+    )
+    assert cfg.prices.aichemy_pricing.cache_path == Path(
+        "data/interim/aichemy_pricing_cache.sqlite"
+    )
+    # Literal must accept the new value without raising.
+    PricesConfig(backend="aichemy_pricing")
+
+
 def test_loads_base_yaml(tmp_path: Path) -> None:
     base = _write(
         tmp_path,


### PR DESCRIPTION
## Summary

Glue PR for Sub-Plan E. Wires the standalone `aichemy_pricing` package into a usable shape: a public re-export surface, an opinionated `build_default_chain()` factory, the `LookupByInchikey` resolver→chain adapter, the `aichemy-price` Typer CLI, and an opt-in `aichemy_pricing` backend in `aichemy.preprocessing.augment.prices`.

Branched off `pricing-integration` (depends on PRs A/B/C/D/F/G already merged there). Targets `pricing-integration`, not `main`.

### Two corrections vs. the original sub-plan E text

The original plan was written pre-PR-#27/#29 pivot. Two adjustments to match what's actually on `pricing-integration`:

1. **`EnamineVendor`, `CaymanVendor`, `ChemCruzVendor` are not standalone vendor classes.** They live as Browserbase parsers — Enamine via L3b Browser API, ChemCruz via L3a Fetch, Cayman/Sigma still TBD. The `__init__.py` re-export list and `cli._VENDORS` map drop those three entries; only the four real direct-HTTP vendor classes (Fluorochem, Tocris, Molbase, MedChemExpress) ship as classes.
2. **L3 is two layers, not one.** `build_default_chain` appends both `BrowserbaseFetchLookup` (L3a, SSR HTML; chemcruz parser registered today) AND `BrowserbaseBrowserLookup` (L3b, JS-rendered SPAs; enamine parser registered today). Both no-op when `BROWSERBASE_API_KEY` is unset, so they're safe to include unconditionally.

### What ships

- `src/aichemy_pricing/__init__.py` — full public re-export (types, protocols, chain composition, HTTP factories, rate limiter, three resolvers, four direct-HTTP vendors, both L3 lookups, `LookupByInchikey`, `build_default_chain`).
- `src/aichemy_pricing/lookup_by_inchikey.py` — resolver → chain adapter.
- `src/aichemy_pricing/cli.py` — `aichemy-price` with `lookup`, `chain`, `resolve`. The `lookup` subcommand wraps `_VENDORS[vendor]()` in `try/except NotImplementedError → typer.Exit(2)` for clean placeholder messages (Revision 27). `chain` walks the union of direct-HTTP vendors plus both L3 parser registries through a real `build_default_chain`.
- `src/aichemy/config.py` — adds `AichemyPricingConfig` sub-model (catalog_dir + cache_path) and widens `PricesConfig.backend` Literal to `{stub, chained, aichemy_pricing}`. Default backend stays `chained`.
- `src/aichemy/preprocessing/augment/prices.py` — adds an `aichemy_pricing` branch to `make_lookup` returning `_InchikeyAdapter(LookupByInchikey(resolver, chain))`. Static FX-to-USD table dated 2026-04-25 covers every member of `aichemy_pricing.types.Currency`. `_check_fx_freshness()` warns when the table is >120 days stale (Revision 28). RDKit `MolToInchiKey` wrapped in `try/except` (Revision 26).
- `configs/default.yaml` — adds the `aichemy_pricing:` sub-block with default paths; default backend unchanged.
- `tests/integration/test_pricing_package_integration.py` — FX-table-covers-every-Currency-literal assertion (Revision 10) + Fluorochem fixture round-trip through the full default chain.
- `tests/unit/test_config.py` — extends with `test_prices_aichemy_pricing_backend_schema`.
- `README.md` — appended a "Vendor pricing" section listing real (post-pivot) vendor coverage.

### Test counts

| Suite | Result |
|---|---|
| `src/aichemy_pricing/tests/` (101 tests) | 101 passed, 7 live skipped |
| `tests/integration/test_pricing_package_integration.py` | 2 passed |
| `tests/` full AIchemy suite | 221 passed (no new failures from this PR; 2–3 pre-existing failures in this env are missing-`synrbl`-extra issues unrelated to pricing) |
| `mypy src/aichemy_pricing/` + `mypy src/aichemy/preprocessing/augment/prices.py` | clean |
| `ruff check` + `ruff format --check` | clean |
| `aichemy-price --version` / `aichemy-price lookup fluorochem F765353-1G` | works (live: `230.0 GBP / 1.0 g`) |

### Out of scope

- Running on the full 100K-compound corpus with `backend=aichemy_pricing` — separate driver-script PR.
- Registering Cayman / Sigma / Tocris-via-browser parsers in `browser_parsers/__init__.py` — only `enamine` is calibrated today.
- Live FX feed — ships static 2026-04-25 ECB table with the 120-day staleness warning.

## Test plan

- [x] `uv run pytest src/aichemy_pricing/tests/ tests/integration/test_pricing_package_integration.py -v` — all green
- [x] `uv run pytest tests/ -v` — no new regressions
- [x] `uv run mypy src/aichemy_pricing/ src/aichemy/preprocessing/augment/prices.py` — clean
- [x] `uv run ruff check src/aichemy_pricing/ src/aichemy/preprocessing/augment/prices.py` — clean
- [x] `uv run aichemy-price --version` — prints `0.1.0`
- [x] `uv run aichemy-price lookup fluorochem F765353-1G` — live hit returns `230.0 GBP / 1.0 g`
- [ ] `uv run dvc repro augment_prices` — environment-blocked here (upstream-stage parquet outputs are not present in this dev env); reviewer should confirm in a populated env
- [x] Default backend remains `chained` (no behavior change for current users)

https://claude.ai/code/session_0186ecfPtpEyXkRnrwPvsy1h

---
_Generated by [Claude Code](https://claude.ai/code/session_0186ecfPtpEyXkRnrwPvsy1h)_