### PR TITLE
fix(licensing): migrate patent fetch from PatentsView to USPTO ODP

### DIFF
--- a/docs/superpowers/specs/2026-04-25-aichemy-pricing-licensing-design.md
+++ b/docs/superpowers/specs/2026-04-25-aichemy-pricing-licensing-design.md
@@ -254,6 +254,7 @@ Full `dvc repro` on the existing tiny fixture (`tests/fixtures/`), with PatentsV
 3. **The patent associated with a reaction is the patent it was *extracted from*** (Lowe dataset provenance), not necessarily the patent that *legally protects* the route. A reaction might be prior art the patent merely cites. The LLM classifier mitigates this when the patent's claims clearly cover something else, but doesn't eliminate the issue.
 4. **Process royalty on intermediate-only reactions** uses implied market-price revenue rather than a per-unit-of-chemistry fee — a modeling choice rather than a fact about how license deals work.
 5. **Royalty rate range \[0%, 8%\] is industry-typical for fine/specialty chemistry** but actual deals vary widely. The sweep is intended to demonstrate decision robustness within this range, not predict the rate of any specific deal.
+6. **PatentsView v1 endpoint deprecated.** As of 2026-04, the entire `patentsview.org` host (root, `search.*`, `api.*`) returns 301-redirect to the USPTO ODP transition guide; PatentsView is retired. The fetch client now targets the USPTO Open Data Portal (`api.uspto.gov`), which requires a free API key in `USPTO_ODP_API_KEY`. ODP splits metadata and full text across two endpoints — abstract/claims are fetched per-patent from the grant XML (~2× the request count vs PatentsView v1). The captured ODP contract is documented inline on `_parse_response` in `src/aichemy/preprocessing/patents/fetch.py`.
 
 ## Out of scope
 

--- a/src/aichemy/cli.py
+++ b/src/aichemy/cli.py
@@ -675,11 +675,22 @@ def patents_fetch(
     config: Path = ConfigOpt,
     override: list[Path] = OverrideOpt,
 ) -> None:
-    """Fetch PatentsView metadata for every USPTO patent referenced by reactions."""
+    """Fetch USPTO ODP metadata for every USPTO patent referenced by reactions."""
+    import os
+
     from aichemy.preprocessing.patents.fetch import (
+        API_KEY_ENV,
         fetch_patents,
         write_metadata_parquet,
     )
+
+    if not os.environ.get(API_KEY_ENV):
+        typer.echo(
+            f"[patents fetch] {API_KEY_ENV} env var is required "
+            "(get a free key at https://developer.uspto.gov)",
+            err=True,
+        )
+        raise typer.Exit(1)
 
     cfg = _load(config, override)
     reactions = read_reactions(interim_path(cfg, "augmented", "reactions_full.parquet"))

--- a/src/aichemy/config.py
+++ b/src/aichemy/config.py
@@ -41,7 +41,7 @@ class YieldConfig(BaseModel):
 class LicensesConfig(BaseModel):
     model_config = {"extra": "forbid"}
 
-    patentsview_endpoint: str = "https://search.patentsview.org/api/v1/patent"
+    patentsview_endpoint: str = "https://api.uspto.gov/api/v1/patent/applications/search"
     cpc_rules_path: Path = Field(default_factory=lambda: Path("configs/cpc_rules.yaml"))
     cache_path: Path = Field(default_factory=lambda: Path("data/interim/licenses/llm_cache.jsonl"))
     llm_model: str = "claude-haiku-4-5"

--- a/src/aichemy/preprocessing/patents/fetch.py
+++ b/src/aichemy/preprocessing/patents/fetch.py
@@ -30,6 +30,18 @@ log = logging.getLogger(__name__)
 
 API_KEY_ENV = "USPTO_ODP_API_KEY"
 
+_GRANT_AUTH_ERROR_STATUSES = frozenset({401, 403, 429})
+
+
+class GrantFetchError(Exception):
+    """Raised by _fetch_grant_xml when the server returns an auth/rate-limit error.
+
+    HTTP 401, 403, or 429 from either the file-location lookup or the
+    signed-URL download are unrecoverable without operator action (bad key,
+    insufficient permissions, or quota exhausted), so they propagate up to
+    _fetch_batch which sets fetch_status="error" on the parent record.
+    """
+
 
 @dataclass
 class PatentMetadata:
@@ -118,7 +130,16 @@ def _fetch_batch(
                     )
                     if not file_uri:
                         continue
-                    xml = _fetch_grant_xml(file_uri, api_key)
+                    try:
+                        xml = _fetch_grant_xml(file_uri, api_key)
+                    except GrantFetchError as exc:
+                        log.warning(
+                            "Grant XML auth/rate-limit error for %s: %s",
+                            rec.patent_number,
+                            exc,
+                        )
+                        rec.fetch_status = "error"
+                        continue
                     if xml is None:
                         continue
                     abstract, claims_text = _parse_grant_xml(xml)
@@ -235,8 +256,15 @@ def _fetch_grant_xml(file_uri: str, api_key: str) -> str | None:
             no ``Location`` header — both shapes are handled.
       2. GET <signed-url>  (no auth header)
          -> 200, full grant XML
-    Returns the XML body, or None on any failure (caller treats this as
-    no-abstract/no-claims; metadata still counts as fetched).
+
+    Returns the XML body on success, or None when the grant XML is genuinely
+    absent (no signed URL in response, non-auth non-200 on signed download).
+    Callers should keep fetch_status="ok" in that case — it is data absence,
+    not an API error.
+
+    Raises GrantFetchError for HTTP 401/403/429 from either step — these
+    indicate a bad/expired key, insufficient permissions, or exhausted quota
+    and require operator action; the caller should set fetch_status="error".
     """
     try:
         r = requests.get(
@@ -245,6 +273,10 @@ def _fetch_grant_xml(file_uri: str, api_key: str) -> str | None:
             timeout=30,
             allow_redirects=False,
         )
+        if r.status_code in _GRANT_AUTH_ERROR_STATUSES:
+            raise GrantFetchError(
+                f"file-location lookup returned HTTP {r.status_code}"
+            )
         signed_url = r.headers.get("Location")
         if not signed_url:
             m = re.search(r"https://data\.uspto\.gov/[^\s\"]+", r.text)
@@ -256,10 +288,16 @@ def _fetch_grant_xml(file_uri: str, api_key: str) -> str | None:
                 return None
             signed_url = m.group(0).rstrip(".")
         rr = requests.get(signed_url, timeout=60)
+        if rr.status_code in _GRANT_AUTH_ERROR_STATUSES:
+            raise GrantFetchError(
+                f"signed-URL download returned HTTP {rr.status_code}"
+            )
         if rr.status_code != 200:
             log.warning("Grant XML download returned %s", rr.status_code)
             return None
         return rr.text
+    except GrantFetchError:
+        raise
     except requests.RequestException as exc:
         log.warning("Grant XML fetch failed: %s", exc)
         return None

--- a/src/aichemy/preprocessing/patents/fetch.py
+++ b/src/aichemy/preprocessing/patents/fetch.py
@@ -1,13 +1,23 @@
-"""PatentsView REST client.
+"""USPTO Open Data Portal (ODP) REST client.
 
 Fetches patent metadata (filing date, abstract, claims, CPC codes) for the
 USPTO patent numbers extracted from reaction `rxn_id`s. Used by the
 `fetch_patent_metadata` DVC stage.
+
+PatentsView (search.patentsview.org and api.patentsview.org) was retired in
+April 2026 — every path now 301-redirects to the USPTO ODP transition guide.
+This module targets the ODP at api.uspto.gov, which requires a free API key
+(signup at developer.uspto.gov, supply via the ``USPTO_ODP_API_KEY`` env
+var). ODP splits metadata and full text across two endpoints — search returns
+metadata + a per-record ``fileLocationURI``, which is downloaded separately
+(two-step: auth'd indirection + signed URL) and parsed for abstract/claims.
 """
 
 from __future__ import annotations
 
 import logging
+import os
+import re
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -17,6 +27,8 @@ import polars as pl
 import requests
 
 log = logging.getLogger(__name__)
+
+API_KEY_ENV = "USPTO_ODP_API_KEY"
 
 
 @dataclass
@@ -47,22 +59,33 @@ def fetch_patents(
     patent_numbers: list[str],
     *,
     endpoint: str,
+    api_key: str | None = None,
     max_retries: int = 3,
     batch_size: int = 25,
     backoff_seconds: float = 1.0,
 ) -> list[PatentMetadata]:
-    """Fetch metadata for the given patent numbers.
+    """Fetch metadata for the given patent numbers from the USPTO ODP.
 
-    PatentsView accepts a JSON POST with a query in its query DSL. We batch
-    requests to amortize round-trip cost, retry on transient errors, and
-    record `fetch_status="error"` on permanent failure (rather than raise,
-    so the pipeline doesn't crash).
+    Each batch is one Lucene OR-query against the ODP search endpoint; each
+    hit triggers a follow-up two-step grant-XML download for abstract/claims.
+    Returns one ``PatentMetadata`` per input number, with status:
+      - ``"ok"``        — search hit + (optional) XML parsed
+      - ``"not_found"`` — search returned no record for that number
+      - ``"error"``     — search retries exhausted on a permanent failure
     """
+    if api_key is None:
+        api_key = os.environ.get(API_KEY_ENV)
+    if not api_key:
+        raise RuntimeError(
+            f"{API_KEY_ENV} is not set; obtain a free key at "
+            "https://developer.uspto.gov and export it before running"
+        )
+
     out: list[PatentMetadata] = []
     seen: set[str] = set()
     for i in range(0, len(patent_numbers), batch_size):
         batch = patent_numbers[i : i + batch_size]
-        results = _fetch_batch(batch, endpoint, max_retries, backoff_seconds)
+        results = _fetch_batch(batch, endpoint, api_key, max_retries, backoff_seconds)
         for r in results:
             seen.add(r.patent_number)
             out.append(r)
@@ -75,78 +98,212 @@ def fetch_patents(
 def _fetch_batch(
     batch: list[str],
     endpoint: str,
+    api_key: str,
     max_retries: int,
     backoff_seconds: float,
 ) -> list[PatentMetadata]:
-    payload = {
-        "q": {"patent_number": batch},
-        "f": [
-            "patent_number",
-            "patent_date",
-            "patent_abstract",
-            "claims",
-            "cpcs",
-            "assignees",
-            "application",
-        ],
-        "o": {"per_page": len(batch)},
-    }
+    q = "applicationMetaData.patentNumber:(" + " OR ".join(batch) + ")"
+    headers = {"X-API-Key": api_key, "Accept": "application/json"}
+    params = {"q": q, "limit": str(len(batch))}
     for attempt in range(max_retries):
         try:
-            r = requests.post(endpoint, json=payload, timeout=30)
+            r = requests.get(endpoint, params=params, headers=headers, timeout=30)
             if r.status_code == 200:
-                return _parse_response(r.json(), batch)
+                pairs = _parse_response(r.json(), batch)
+                for rec, raw in pairs:
+                    if rec.fetch_status != "ok":
+                        continue
+                    file_uri = (raw.get("grantDocumentMetaData") or {}).get(
+                        "fileLocationURI"
+                    )
+                    if not file_uri:
+                        continue
+                    xml = _fetch_grant_xml(file_uri, api_key)
+                    if xml is None:
+                        continue
+                    abstract, claims_text = _parse_grant_xml(xml)
+                    rec.abstract = abstract
+                    rec.claims_text = claims_text
+                return [rec for rec, _ in pairs]
+            if r.status_code == 404:
+                # ODP returns 404 with "No matching records found" — treat the
+                # whole batch as not_found rather than retry.
+                return [_not_found_record(pn) for pn in batch]
             if r.status_code in (429, 500, 502, 503, 504) and attempt < max_retries - 1:
                 time.sleep(backoff_seconds * (2**attempt))
                 continue
-            log.warning("PatentsView returned %s for batch=%s", r.status_code, batch[:3])
+            log.warning("ODP search returned %s for batch=%s", r.status_code, batch[:3])
             break
         except requests.RequestException as exc:
-            log.warning("PatentsView request failed (attempt %d): %s", attempt + 1, exc)
+            log.warning("ODP search request failed (attempt %d): %s", attempt + 1, exc)
             if attempt < max_retries - 1:
                 time.sleep(backoff_seconds * (2**attempt))
                 continue
     return [_error_record(pn) for pn in batch]
 
 
-def _parse_response(body: dict[str, Any], batch: list[str]) -> list[PatentMetadata]:
-    by_id: dict[str, PatentMetadata] = {}
-    for p in body.get("patents") or []:
-        pn = str(p.get("patent_number"))
-        claims_text = " ".join(c.get("text", "") for c in (p.get("claims") or []))
-        cpc_codes = [c.get("cpc_group_id", "") for c in (p.get("cpcs") or [])]
-        cpc_codes = [c for c in cpc_codes if c]
-        assignees = p.get("assignees") or []
-        assignee = assignees[0].get("assignee_organization") if assignees else None
-        application = p.get("application") or {}
-        by_id[pn] = PatentMetadata(
-            patent_number=pn,
-            filing_date=application.get("filing_date"),
-            grant_date=p.get("patent_date"),
-            abstract=p.get("patent_abstract"),
-            claims_text=claims_text or None,
-            cpc_codes=cpc_codes,
-            assignee=assignee,
-            fetch_status="ok",
+def _parse_response(
+    body: dict[str, Any], batch: list[str]
+) -> list[tuple[PatentMetadata, dict[str, Any]]]:
+    """Map a USPTO ODP search response to (PatentMetadata, raw_record) pairs.
+
+    Captured contract (curl, 2026-04-26, against api.uspto.gov):
+      body = {
+        "count": int,
+        "patentFileWrapperDataBag": [{
+          "applicationNumberText": str,
+          "applicationMetaData": {
+            "patentNumber": str | null,
+            "grantDate": str | null,         # YYYY-MM-DD
+            "filingDate": str | null,        # YYYY-MM-DD
+            "inventionTitle": str | null,
+            "cpcClassificationBag": list[str],   # e.g. "B01J  29/084"
+                                                 # (extra whitespace; collapsed)
+            "firstApplicantName": str | null,
+            ...
+          },
+          "assignmentBag": [
+            {"assigneeBag": [{"assigneeNameText": str}, ...]},
+            ...
+          ],
+          "grantDocumentMetaData": {"fileLocationURI": str},
+          ...
+        }, ...],
+        "requestIdentifier": str,
+      }
+
+    Patent numbers absent from the result set become fetch_status="not_found".
+    abstract + claims_text are NOT in this response — they come from the
+    grant XML fetched via grantDocumentMetaData.fileLocationURI by
+    _fetch_grant_xml / _parse_grant_xml. PatentsView v1 returned them inline;
+    ODP does not.
+    """
+    by_id: dict[str, tuple[PatentMetadata, dict[str, Any]]] = {}
+    for record in body.get("patentFileWrapperDataBag") or []:
+        meta = record.get("applicationMetaData") or {}
+        pn = meta.get("patentNumber")
+        if not pn:
+            continue
+        pn = str(pn)
+
+        cpc_raw = meta.get("cpcClassificationBag") or []
+        cpc_codes = [re.sub(r"\s+", " ", c).strip() for c in cpc_raw if c]
+
+        assignee = None
+        for ab in record.get("assignmentBag") or []:
+            for entry in ab.get("assigneeBag") or []:
+                name = entry.get("assigneeNameText")
+                if name:
+                    assignee = name
+                    break
+            if assignee:
+                break
+        if assignee is None:
+            assignee = meta.get("firstApplicantName")
+
+        by_id[pn] = (
+            PatentMetadata(
+                patent_number=pn,
+                filing_date=meta.get("filingDate"),
+                grant_date=meta.get("grantDate"),
+                abstract=None,
+                claims_text=None,
+                cpc_codes=cpc_codes,
+                assignee=assignee,
+                fetch_status="ok",
+            ),
+            record,
         )
-    out: list[PatentMetadata] = []
+
+    out: list[tuple[PatentMetadata, dict[str, Any]]] = []
     for pn in batch:
         if pn in by_id:
             out.append(by_id[pn])
         else:
-            out.append(
-                PatentMetadata(
-                    patent_number=pn,
-                    filing_date=None,
-                    grant_date=None,
-                    abstract=None,
-                    claims_text=None,
-                    cpc_codes=[],
-                    assignee=None,
-                    fetch_status="not_found",
-                )
-            )
+            out.append((_not_found_record(pn), {}))
     return out
+
+
+def _fetch_grant_xml(file_uri: str, api_key: str) -> str | None:
+    """Resolve and download the grant XML pointed to by an ODP fileLocationURI.
+
+    Two-step protocol:
+      1. GET <file_uri>  with X-API-Key, ``allow_redirects=False``
+         -> 302 with ``Location: <signed-url>`` (also echoed in body as
+            ``"Use redirect URL to download: <signed-url>. IMPORTANT..."``).
+            Older / mocked variants may return 200 with the same body and
+            no ``Location`` header — both shapes are handled.
+      2. GET <signed-url>  (no auth header)
+         -> 200, full grant XML
+    Returns the XML body, or None on any failure (caller treats this as
+    no-abstract/no-claims; metadata still counts as fetched).
+    """
+    try:
+        r = requests.get(
+            file_uri,
+            headers={"X-API-Key": api_key, "Accept": "application/json"},
+            timeout=30,
+            allow_redirects=False,
+        )
+        signed_url = r.headers.get("Location")
+        if not signed_url:
+            m = re.search(r"https://data\.uspto\.gov/[^\s\"]+", r.text)
+            if not m:
+                log.warning(
+                    "ODP file-location lookup returned %s with no signed URL",
+                    r.status_code,
+                )
+                return None
+            signed_url = m.group(0).rstrip(".")
+        rr = requests.get(signed_url, timeout=60)
+        if rr.status_code != 200:
+            log.warning("Grant XML download returned %s", rr.status_code)
+            return None
+        return rr.text
+    except requests.RequestException as exc:
+        log.warning("Grant XML fetch failed: %s", exc)
+        return None
+
+
+def _parse_grant_xml(xml: str) -> tuple[str | None, str | None]:
+    """Extract abstract + concatenated claims text from a USPTO grant XML.
+
+    Regex-based (USPTO grant XML has variable namespace/DTD shape; full XML
+    parsing trips on the entity declarations on older patents). Multiple
+    <claim ...>...</claim> blocks are concatenated newline-separated.
+    Inner tags are stripped; whitespace collapsed. Returns (None, None) if
+    the corresponding tag isn't present.
+    """
+    abstract: str | None = None
+    m = re.search(r"<abstract\b[^>]*>(.*?)</abstract>", xml, re.DOTALL)
+    if m:
+        abstract = re.sub(r"\s+", " ", re.sub(r"<[^>]+>", "", m.group(1))).strip() or None
+
+    claim_blocks = re.findall(r"<claim(?:\s[^>]*)?>(.*?)</claim>", xml, re.DOTALL)
+    claims_text: str | None = None
+    if claim_blocks:
+        cleaned = [
+            re.sub(r"\s+", " ", re.sub(r"<[^>]+>", "", b)).strip()
+            for b in claim_blocks
+        ]
+        cleaned = [c for c in cleaned if c]
+        if cleaned:
+            claims_text = "\n".join(cleaned)
+
+    return abstract, claims_text
+
+
+def _not_found_record(patent_number: str) -> PatentMetadata:
+    return PatentMetadata(
+        patent_number=patent_number,
+        filing_date=None,
+        grant_date=None,
+        abstract=None,
+        claims_text=None,
+        cpc_codes=[],
+        assignee=None,
+        fetch_status="not_found",
+    )
 
 
 def _error_record(patent_number: str) -> PatentMetadata:

--- a/src/aichemy/preprocessing/patents/fetch.py
+++ b/src/aichemy/preprocessing/patents/fetch.py
@@ -125,9 +125,7 @@ def _fetch_batch(
                 for rec, raw in pairs:
                     if rec.fetch_status != "ok":
                         continue
-                    file_uri = (raw.get("grantDocumentMetaData") or {}).get(
-                        "fileLocationURI"
-                    )
+                    file_uri = (raw.get("grantDocumentMetaData") or {}).get("fileLocationURI")
                     if not file_uri:
                         continue
                     try:
@@ -274,9 +272,7 @@ def _fetch_grant_xml(file_uri: str, api_key: str) -> str | None:
             allow_redirects=False,
         )
         if r.status_code in _GRANT_AUTH_ERROR_STATUSES:
-            raise GrantFetchError(
-                f"file-location lookup returned HTTP {r.status_code}"
-            )
+            raise GrantFetchError(f"file-location lookup returned HTTP {r.status_code}")
         signed_url = r.headers.get("Location")
         if not signed_url:
             m = re.search(r"https://data\.uspto\.gov/[^\s\"]+", r.text)
@@ -289,9 +285,7 @@ def _fetch_grant_xml(file_uri: str, api_key: str) -> str | None:
             signed_url = m.group(0).rstrip(".")
         rr = requests.get(signed_url, timeout=60)
         if rr.status_code in _GRANT_AUTH_ERROR_STATUSES:
-            raise GrantFetchError(
-                f"signed-URL download returned HTTP {rr.status_code}"
-            )
+            raise GrantFetchError(f"signed-URL download returned HTTP {rr.status_code}")
         if rr.status_code != 200:
             log.warning("Grant XML download returned %s", rr.status_code)
             return None
@@ -320,10 +314,7 @@ def _parse_grant_xml(xml: str) -> tuple[str | None, str | None]:
     claim_blocks = re.findall(r"<claim(?:\s[^>]*)?>(.*?)</claim>", xml, re.DOTALL)
     claims_text: str | None = None
     if claim_blocks:
-        cleaned = [
-            re.sub(r"\s+", " ", re.sub(r"<[^>]+>", "", b)).strip()
-            for b in claim_blocks
-        ]
+        cleaned = [re.sub(r"\s+", " ", re.sub(r"<[^>]+>", "", b)).strip() for b in claim_blocks]
         cleaned = [c for c in cleaned if c]
         if cleaned:
             claims_text = "\n".join(cleaned)

--- a/tests/fixtures/patents/sample_patentsview_response.json
+++ b/tests/fixtures/patents/sample_patentsview_response.json
@@ -1,25 +1,31 @@
 {
-  "patents": [
+  "count": 1,
+  "patentFileWrapperDataBag": [
     {
-      "patent_number": "7456123",
-      "patent_date": "2008-11-25",
-      "patent_abstract": "A method for the synthesis of substituted heterocyclic compounds...",
-      "claims": [{"text": "1. A process for preparing a compound of formula I..."}],
-      "cpcs": [
-        {"cpc_group_id": "C07D 401/12"},
-        {"cpc_group_id": "A61K 31/505"}
+      "applicationNumberText": "11106297",
+      "applicationMetaData": {
+        "patentNumber": "7456123",
+        "grantDate": "2008-11-25",
+        "filingDate": "2005-04-14",
+        "inventionTitle": "FCC CATALYST",
+        "cpcClassificationBag": [
+          "B01J  29/084",
+          "B01J  35/647",
+          "C10G  11/02"
+        ],
+        "firstApplicantName": "ExxonMobil Research and Engineering Company"
+      },
+      "assignmentBag": [
+        {
+          "assigneeBag": [
+            {"assigneeNameText": "EXXONMOBIL RESEARCH & ENGINEERING CO."}
+          ]
+        }
       ],
-      "assignees": [{"assignee_organization": "Acme Pharmaceuticals"}],
-      "application": {"filing_date": "2005-03-14"}
-    },
-    {
-      "patent_number": "9999999",
-      "patent_date": null,
-      "patent_abstract": null,
-      "claims": [],
-      "cpcs": [],
-      "assignees": [],
-      "application": {"filing_date": "1985-01-01"}
+      "grantDocumentMetaData": {
+        "fileLocationURI": "https://api.uspto.gov/api/v1/datasets/products/files/PTGRXML-SPLT/2008/ipg081125/11106297_07456123.xml"
+      }
     }
-  ]
+  ],
+  "requestIdentifier": "fixture-7456123"
 }

--- a/tests/integration/test_dvc_repro_licenses.py
+++ b/tests/integration/test_dvc_repro_licenses.py
@@ -1,8 +1,8 @@
 """End-to-end integration test for the licensing stages.
 
-Runs the four new pipeline stages on a tiny synthetic fixture, with
-PatentsView calls stubbed via ``responses`` and Anthropic calls stubbed
-via a ``MagicMock`` client. Verifies the data flows through to the
+Runs the four new pipeline stages on a tiny synthetic fixture, with USPTO
+ODP calls stubbed via ``responses`` and Anthropic calls stubbed via a
+``MagicMock`` client. Verifies the data flows through to the
 ``augment_licenses`` output with correct columns for both USPTO and
 MetaNetX rows (the latter exercises the left-join + ``fill_null(False)``
 fallback path).
@@ -18,7 +18,20 @@ import polars as pl
 import pytest
 import responses
 
-PATENTSVIEW = "https://search.patentsview.org/api/v1/patent"
+ODP_SEARCH = "https://api.uspto.gov/api/v1/patent/applications/search"
+ODP_FILE_URI = (
+    "https://api.uspto.gov/api/v1/datasets/products/files/PTGRXML-SPLT/"
+    "2015/ipg150915/12345678_07456123.xml"
+)
+ODP_SIGNED_URL = "https://data.uspto.gov/files/integration-sample.xml"
+SAMPLE_GRANT_XML = """<?xml version="1.0"?>
+<us-patent-grant>
+  <abstract id="abstract"><p>A medicinal preparation.</p></abstract>
+  <claims>
+    <claim id="CLM-00001"><claim-text>1. A composition comprising the active.</claim-text></claim>
+  </claims>
+</us-patent-grant>
+"""
 
 
 @pytest.fixture
@@ -54,23 +67,38 @@ def test_full_license_flow_with_stubbed_apis(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     responses.add(
-        responses.POST,
-        PATENTSVIEW,
+        responses.GET,
+        ODP_SEARCH,
         json={
-            "patents": [
+            "count": 1,
+            "patentFileWrapperDataBag": [
                 {
-                    "patent_number": "7456123",
-                    "patent_date": "2008-11-25",
-                    "patent_abstract": "A medicinal preparation for…",
-                    "claims": [{"text": "1. A composition comprising…"}],
-                    "cpcs": [{"cpc_group_id": "A61K 31/505"}],
-                    "assignees": [{"assignee_organization": "Acme"}],
-                    "application": {"filing_date": "2015-03-14"},
+                    "applicationNumberText": "12345678",
+                    "applicationMetaData": {
+                        "patentNumber": "7456123",
+                        "grantDate": "2015-09-15",
+                        "filingDate": "2015-03-14",
+                        "inventionTitle": "MEDICINAL PREPARATION",
+                        "cpcClassificationBag": ["A61K 31/505"],
+                    },
+                    "assignmentBag": [
+                        {"assigneeBag": [{"assigneeNameText": "Acme"}]}
+                    ],
+                    "grantDocumentMetaData": {"fileLocationURI": ODP_FILE_URI},
                 }
-            ]
+            ],
+            "requestIdentifier": "integration-test",
         },
         status=200,
     )
+    responses.add(
+        responses.GET,
+        ODP_FILE_URI,
+        body=f'"Use redirect URL to download: {ODP_SIGNED_URL}. IMPORTANT..."',
+        status=200,
+    )
+    responses.add(responses.GET, ODP_SIGNED_URL, body=SAMPLE_GRANT_XML, status=200)
+    monkeypatch.setenv("USPTO_ODP_API_KEY", "fake-key-for-test")
 
     fake_block = MagicMock()
     fake_block.type = "tool_use"
@@ -108,7 +136,7 @@ def test_full_license_flow_with_stubbed_apis(
     reactions = pl.read_parquet(fake_reactions_full)
 
     # 1. fetch_patent_metadata
-    items = fetch_patents(["7456123"], endpoint=PATENTSVIEW, max_retries=1)
+    items = fetch_patents(["7456123"], endpoint=ODP_SEARCH, max_retries=1)
     patents_path = tmp_path / "patent_metadata.parquet"
     write_metadata_parquet(items, patents_path)
 

--- a/tests/integration/test_dvc_repro_licenses.py
+++ b/tests/integration/test_dvc_repro_licenses.py
@@ -81,9 +81,7 @@ def test_full_license_flow_with_stubbed_apis(
                         "inventionTitle": "MEDICINAL PREPARATION",
                         "cpcClassificationBag": ["A61K 31/505"],
                     },
-                    "assignmentBag": [
-                        {"assigneeBag": [{"assigneeNameText": "Acme"}]}
-                    ],
+                    "assignmentBag": [{"assigneeBag": [{"assigneeNameText": "Acme"}]}],
                     "grantDocumentMetaData": {"fileLocationURI": ODP_FILE_URI},
                 }
             ],

--- a/tests/unit/test_config_licenses.py
+++ b/tests/unit/test_config_licenses.py
@@ -7,7 +7,7 @@ from aichemy.config import LicensesConfig, load_config
 
 def test_licenses_config_defaults():
     cfg = LicensesConfig()
-    assert cfg.patentsview_endpoint == "https://search.patentsview.org/api/v1/patent"
+    assert cfg.patentsview_endpoint == "https://api.uspto.gov/api/v1/patent/applications/search"
     assert cfg.llm_model == "claude-haiku-4-5"
     assert cfg.cpc_rules_path == Path("configs/cpc_rules.yaml")
     assert cfg.cache_path == Path("data/interim/licenses/llm_cache.jsonl")

--- a/tests/unit/test_patents_fetch.py
+++ b/tests/unit/test_patents_fetch.py
@@ -24,8 +24,12 @@ SAMPLE_GRANT_XML = """<?xml version="1.0"?>
     <p>A method for the synthesis of substituted heterocyclic compounds.</p>
   </abstract>
   <claims>
-    <claim id="CLM-00001"><claim-text>1. A process for preparing a compound of formula I.</claim-text></claim>
-    <claim id="CLM-00002"><claim-text>2. The process of claim 1.</claim-text></claim>
+    <claim id="CLM-00001">
+      <claim-text>1. A process for preparing a compound of formula I.</claim-text>
+    </claim>
+    <claim id="CLM-00002">
+      <claim-text>2. The process of claim 1.</claim-text>
+    </claim>
   </claims>
 </us-patent-grant>
 """

--- a/tests/unit/test_patents_fetch.py
+++ b/tests/unit/test_patents_fetch.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 import polars as pl
+import pytest
 import responses
 
 from aichemy.preprocessing.patents.fetch import (
@@ -11,32 +12,66 @@ from aichemy.preprocessing.patents.fetch import (
 )
 
 FIXTURE = Path(__file__).parent.parent / "fixtures" / "patents" / "sample_patentsview_response.json"
-ENDPOINT = "https://search.patentsview.org/api/v1/patent"
+ENDPOINT = "https://api.uspto.gov/api/v1/patent/applications/search"
+GRANT_FILE_URI = (
+    "https://api.uspto.gov/api/v1/datasets/products/files/PTGRXML-SPLT/"
+    "2008/ipg081125/11106297_07456123.xml"
+)
+SIGNED_URL = "https://data.uspto.gov/files/sample.xml"
+SAMPLE_GRANT_XML = """<?xml version="1.0"?>
+<us-patent-grant>
+  <abstract id="abstract">
+    <p>A method for the synthesis of substituted heterocyclic compounds.</p>
+  </abstract>
+  <claims>
+    <claim id="CLM-00001"><claim-text>1. A process for preparing a compound of formula I.</claim-text></claim>
+    <claim id="CLM-00002"><claim-text>2. The process of claim 1.</claim-text></claim>
+  </claims>
+</us-patent-grant>
+"""
+
+
+@pytest.fixture(autouse=True)
+def _set_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("USPTO_ODP_API_KEY", "fake-key-for-test")
 
 
 @responses.activate
 def test_fetch_patents_returns_metadata_objects():
     responses.add(
-        responses.POST,
+        responses.GET,
         ENDPOINT,
         json=json.loads(FIXTURE.read_text()),
         status=200,
     )
+    responses.add(
+        responses.GET,
+        GRANT_FILE_URI,
+        body=f'"Use redirect URL to download: {SIGNED_URL}. IMPORTANT..."',
+        status=200,
+    )
+    responses.add(responses.GET, SIGNED_URL, body=SAMPLE_GRANT_XML, status=200)
+
     out = fetch_patents(["7456123", "9999999"], endpoint=ENDPOINT, max_retries=1)
     assert len(out) == 2
     by_id = {p.patent_number: p for p in out}
-    assert by_id["7456123"].filing_date == "2005-03-14"
-    assert by_id["7456123"].abstract.startswith("A method")
-    assert "C07D 401/12" in by_id["7456123"].cpc_codes
-    assert by_id["7456123"].claims_text.startswith("1. A process")
+
     assert by_id["7456123"].fetch_status == "ok"
+    assert by_id["7456123"].filing_date == "2005-04-14"
+    assert by_id["7456123"].grant_date == "2008-11-25"
+    assert by_id["7456123"].assignee == "EXXONMOBIL RESEARCH & ENGINEERING CO."
+    assert "B01J 29/084" in by_id["7456123"].cpc_codes
+    assert by_id["7456123"].abstract.startswith("A method")
+    assert by_id["7456123"].claims_text.startswith("1.")
+
+    assert by_id["9999999"].fetch_status == "not_found"
     assert by_id["9999999"].abstract is None
-    assert by_id["9999999"].fetch_status == "ok"
+    assert by_id["9999999"].cpc_codes == []
 
 
 @responses.activate
 def test_fetch_patents_records_error_status_after_retry_exhaustion():
-    responses.add(responses.POST, ENDPOINT, status=500)
+    responses.add(responses.GET, ENDPOINT, status=500)
     out = fetch_patents(["7456123"], endpoint=ENDPOINT, max_retries=2)
     assert len(out) == 1
     assert out[0].fetch_status == "error"

--- a/tests/unit/test_patents_fetch.py
+++ b/tests/unit/test_patents_fetch.py
@@ -81,6 +81,28 @@ def test_fetch_patents_records_error_status_after_retry_exhaustion():
     assert out[0].fetch_status == "error"
 
 
+@responses.activate
+def test_fetch_grant_xml_auth_error_sets_error_status():
+    """401 on the file-location lookup propagates to fetch_status='error'."""
+    responses.add(
+        responses.GET,
+        ENDPOINT,
+        json=json.loads(FIXTURE.read_text()),
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        GRANT_FILE_URI,
+        status=401,
+    )
+
+    out = fetch_patents(["7456123"], endpoint=ENDPOINT, max_retries=1)
+    assert len(out) >= 1
+    by_id = {p.patent_number: p for p in out}
+    assert by_id["7456123"].fetch_status == "error"
+    assert by_id["7456123"].abstract is None
+
+
 def test_patent_metadata_dataclass_shape():
     p = PatentMetadata(
         patent_number="123",


### PR DESCRIPTION
## Summary

PatentsView (`search.patentsview.org` and `api.patentsview.org`) is fully decommissioned — every path 301-redirects to the USPTO ODP transition guide (verified live; real Cloudflare 301, not a sandbox artifact). The originally-proposed `api.patentsview.org/patents/query` URL swap fixes nothing because that host is also dead.

This PR migrates the patent-fetch client to the official replacement, the **USPTO Open Data Portal (ODP)** at `api.uspto.gov`. The ODP requires a free API key (signup at `developer.uspto.gov`) supplied via `USPTO_ODP_API_KEY`, and splits "metadata" and "full text" across two endpoints — abstract and claims now come from a follow-up grant XML download per record (302 to a CloudFront-signed URL, regex-parsed for `<abstract>` and `<claim>` blocks).

### Changes
- `src/aichemy/config.py` — default `patentsview_endpoint` → `https://api.uspto.gov/api/v1/patent/applications/search`
- `src/aichemy/preprocessing/patents/fetch.py` — Lucene OR-batched GET, X-API-Key plumbing, two-step grant XML resolver, regex parser for abstract/claims; new docstring on `_parse_response` documenting the captured live ODP contract
- `src/aichemy/cli.py` — fail-fast on missing `USPTO_ODP_API_KEY` in `aichemy patents fetch`
- `tests/unit/test_patents_fetch.py` — endpoint URL, GET-with-querystring stub, two-step grant XML stub, autouse env-var fixture; `9999999` now correctly asserted as `not_found`
- `tests/integration/test_dvc_repro_licenses.py` — same mock-shape updates; downstream license-classification assertions unchanged
- `tests/fixtures/patents/sample_patentsview_response.json` — replaced with a real ODP search response for patent 7456123 (FCC CATALYST)
- `docs/superpowers/specs/2026-04-25-aichemy-pricing-licensing-design.md` — one new bullet under "Known limitations"

### Live verification
```
USPTO_ODP_API_KEY=… aichemy patents fetch --config configs/default.yaml
[patents fetch] 2 unique USPTO patents to fetch
[patents fetch] wrote 2 rows (2 ok) → data/interim/patents/patent_metadata.parquet

7456123  ok  abstract_len=591   claims_len=8445   cpcs=[B01J 29/084, …]   filing=2005-04-14
9999999  ok  abstract_len=717   claims_len=1456   cpcs=[B29C 45/231, …]  filing=2015-12-07
```
(Unrelated note: 9999999 turned out to be a real US patent — an injection-molding apparatus assigned to Farallon Capital — not the absent-from-USPTO placeholder we'd assumed. The `not_found` path is exercised by the unit test instead, where it's a true gap in the mock response.)

## Test plan

- [x] `uv run pytest tests/unit/test_patents_fetch.py tests/integration/test_dvc_repro_licenses.py -v` → 5/5 green
- [x] Live smoke test: `aichemy patents fetch` against 2 real USPTO numbers returns ≥1 row with `fetch_status=="ok"` and populated abstract / cpc_codes / filing_date — both rows fully populated above
- [x] `_parse_response` docstring matches the live ODP response captured in the fixture
- [x] Diff scope: URL change + env-var plumbing + ODP request/response + grant-XML fetch+parse + mock/fixture/test updates + one design-doc bullet — no solver/MILP changes, no new feature work

---
_Generated by [Claude Code](https://claude.ai/code/session_01HCyz2EM3gpgAGXfhaXmYoZ)_