### PR TITLE
feat(select): add select_reactions stage (top-100k via TF-IDF mol overlap)

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -31,3 +31,10 @@ prices:
 
 paths:
   data_dir: data
+
+selection:
+  # Curated-subset target. ~40,874 rdkit_balanced rows are pinned;
+  # the remainder are filled by TF-IDF mol-overlap with the pinned set.
+  target_total: 100000
+  seed: 42
+  mandatory_column: rdkit_balanced

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -114,6 +114,15 @@ stages:
     outs:
       - data/interim/augmented/reactions_full.parquet
 
+  select_reactions:
+    cmd: uv run aichemy select reactions --config configs/default.yaml
+    deps:
+      - configs/default.yaml
+      - src/aichemy/preprocessing/select.py
+      - data/interim/augmented/reactions_full.parquet
+    outs:
+      - data/interim/selected/reactions.parquet
+
   augment_prices:
     cmd: uv run aichemy augment prices --config configs/default.yaml
     deps:
@@ -130,7 +139,7 @@ stages:
       - configs/default.yaml
       - src/aichemy/preprocessing/export.py
       - data/interim/augmented/molecules_priced.parquet
-      - data/interim/augmented/reactions_full.parquet
+      - data/interim/selected/reactions.parquet
     outs:
       - data/processed/reactions.parquet
       - data/processed/molecules.parquet

--- a/src/aichemy/cli.py
+++ b/src/aichemy/cli.py
@@ -7,6 +7,7 @@ import typer
 
 from aichemy.config import PreprocessingConfig, load_config
 from aichemy.preprocessing import export as export_module
+from aichemy.preprocessing import select as select_module
 from aichemy.preprocessing.augment import directionality as directionality_module
 from aichemy.preprocessing.augment import prices as prices_module
 from aichemy.preprocessing.augment import (
@@ -34,10 +35,12 @@ ingest_app = typer.Typer(help="Ingest raw data from a source.")
 dedup_app = typer.Typer(help="Deduplicate molecules or reactions.")
 balance_app = typer.Typer(help="Balance and validate reaction atom counts.")
 augment_app = typer.Typer(help="Enrich the merged table with yields, prices, directionality.")
+select_app = typer.Typer(help="Curate the post-augmentation reaction set.")
 app.add_typer(ingest_app, name="ingest")
 app.add_typer(dedup_app, name="dedup")
 app.add_typer(balance_app, name="balance")
 app.add_typer(augment_app, name="augment")
+app.add_typer(select_app, name="select")
 app.add_typer(solver_app, name="solve")
 
 
@@ -610,6 +613,43 @@ def augment_directionality(
     typer.echo(f"[augment directionality] wrote {augmented.height} rows.")
 
 
+@select_app.command("reactions")
+def select_reactions_cmd(
+    config: Path = ConfigOpt,
+    override: list[Path] = OverrideOpt,
+) -> None:
+    """Select a curated subset of reactions (TF-IDF mol-overlap; pins rdkit_balanced)."""
+    cfg = _load(config, override)
+    input_path = interim_path(cfg, "augmented", "reactions_full.parquet")
+    output_path = interim_path(cfg, "selected", "reactions.parquet")
+
+    if not input_path.exists():
+        write_empty_reactions(output_path)
+        typer.echo(f"[select reactions] upstream {input_path} missing; wrote empty parquet.")
+        return
+
+    df = read_reactions(input_path)
+    out = select_module.select_reactions(
+        df,
+        target_total=cfg.selection.target_total,
+        seed=cfg.selection.seed,
+        mandatory_column=cfg.selection.mandatory_column,
+    )
+    write_reactions(out, output_path)
+
+    if out.height == 0:
+        typer.echo(f"[select reactions] input empty; wrote {output_path}.")
+        return
+
+    mandatory_kept = int(out.filter(pl.col(cfg.selection.mandatory_column)).height)
+    fill = out.height - mandatory_kept
+    typer.echo(
+        f"[select reactions] selected {out.height:,} of {df.height:,} "
+        f"({mandatory_kept:,} mandatory {cfg.selection.mandatory_column} + "
+        f"{fill:,} by TF-IDF mol overlap)."
+    )
+
+
 @app.command("export")
 def export(
     config: Path = ConfigOpt,
@@ -617,7 +657,7 @@ def export(
 ) -> None:
     """Write final unified hypergraph parquets + manifest.json to data/processed/."""
     cfg = _load(config, override)
-    reactions_in = interim_path(cfg, "augmented", "reactions_full.parquet")
+    reactions_in = interim_path(cfg, "selected", "reactions.parquet")
     molecules_in = interim_path(cfg, "augmented", "molecules_priced.parquet")
     reactions_out = processed_path(cfg, "reactions.parquet")
     molecules_out = processed_path(cfg, "molecules.parquet")

--- a/src/aichemy/config.py
+++ b/src/aichemy/config.py
@@ -50,6 +50,23 @@ class LicensesConfig(BaseModel):
     llm_max_retries: int = 3
 
 
+class SelectionConfig(BaseModel):
+    """Curated-subset selection (Stage 14: select_reactions)."""
+
+    model_config = {"extra": "forbid"}
+
+    # Target total number of reactions in the final selected set.
+    target_total: int = 100_000
+
+    # Seed for reproducible random tiebreaks and score=0 fill order.
+    seed: int = 42
+
+    # The boolean column whose True rows are pinned in the output regardless
+    # of overlap score. "rdkit_balanced" trusts the strict atom-count math;
+    # "balanced" pins the looser SYN-RBL/curator claim.
+    mandatory_column: Literal["rdkit_balanced", "balanced"] = "rdkit_balanced"
+
+
 class MetaNetXURLsConfig(BaseModel):
     model_config = {"extra": "forbid"}
 
@@ -134,6 +151,7 @@ class PreprocessingConfig(BaseModel):
     prices: PricesConfig = Field(default_factory=PricesConfig)
     paths: PathsConfig = Field(default_factory=PathsConfig)
     licenses: LicensesConfig = Field(default_factory=LicensesConfig)
+    selection: SelectionConfig = Field(default_factory=SelectionConfig)
 
 
 def _deep_merge(base: dict[str, Any], override: Mapping[str, Any]) -> dict[str, Any]:

--- a/src/aichemy/preprocessing/select.py
+++ b/src/aichemy/preprocessing/select.py
@@ -45,12 +45,12 @@ def compute_idf(doc_freq: dict[str, int], n_docs: int) -> dict[str, float]:
     }
 
 
-def _row_mol_ids(row: dict) -> set[str]:
+def _row_mol_ids(row: dict[str, list[dict[str, str | float]]]) -> set[str]:
     out: set[str] = set()
     for stoich in row["reactants"]:
-        out.add(stoich["mol_id"])
+        out.add(str(stoich["mol_id"]))
     for stoich in row["products"]:
-        out.add(stoich["mol_id"])
+        out.add(str(stoich["mol_id"]))
     return out
 
 

--- a/src/aichemy/preprocessing/select.py
+++ b/src/aichemy/preprocessing/select.py
@@ -1,0 +1,129 @@
+"""Curated-subset selection (Stage 14: select_reactions).
+
+Given the post-augmentation reactions table, produce a fixed-size subset that
+pins all rows where ``mandatory_column`` is True (typically ``rdkit_balanced``)
+and fills the remainder by preferring candidates whose mol_ids overlap with
+the pinned set, weighted by smoothed TF-IDF so common cofactors (water, ATP,
+NAD+, …) don't dominate the score. Ties are broken by a seeded hash so
+reruns are bit-identical.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from collections import Counter
+
+import polars as pl
+
+
+def compute_mol_doc_freq(df: pl.DataFrame) -> dict[str, int]:
+    """Count, for each mol_id, the number of reactions in which it appears.
+
+    A mol_id is counted at most once per reaction (a row that lists the same
+    mol on both sides, or twice on one side, contributes 1, not 2).
+    """
+    doc_freq: Counter[str] = Counter()
+    for row in df.iter_rows(named=True):
+        mol_ids: set[str] = set()
+        for stoich in row["reactants"]:
+            mol_ids.add(stoich["mol_id"])
+        for stoich in row["products"]:
+            mol_ids.add(stoich["mol_id"])
+        doc_freq.update(mol_ids)
+    return dict(doc_freq)
+
+
+def compute_idf(doc_freq: dict[str, int], n_docs: int) -> dict[str, float]:
+    """Smoothed IDF: ``log((N + 1) / (df + 1)) + 1``.
+
+    The +1s prevent log(0) and ensure idf > 0 for every observed mol.
+    """
+    return {
+        mol_id: math.log((n_docs + 1) / (df_count + 1)) + 1.0
+        for mol_id, df_count in doc_freq.items()
+    }
+
+
+def _row_mol_ids(row: dict) -> set[str]:
+    out: set[str] = set()
+    for stoich in row["reactants"]:
+        out.add(stoich["mol_id"])
+    for stoich in row["products"]:
+        out.add(stoich["mol_id"])
+    return out
+
+
+def score_candidates(
+    candidates: pl.DataFrame,
+    anchor_mol_ids: set[str],
+    idf: dict[str, float],
+) -> pl.Series:
+    """Per-row score = sum of idf weights over mol_ids shared with the anchor set."""
+    scores: list[float] = []
+    for row in candidates.iter_rows(named=True):
+        shared = _row_mol_ids(row) & anchor_mol_ids
+        scores.append(sum(idf.get(m, 0.0) for m in shared))
+    return pl.Series("score", scores, dtype=pl.Float64)
+
+
+def _tiebreak(rxn_id: str, seed: int) -> int:
+    """Deterministic uniform-ish 32-bit int from (rxn_id, seed).
+
+    Uses BLAKE2b instead of Python's built-in hash() because the latter is
+    salted per process (PYTHONHASHSEED) and would make reruns non-reproducible.
+    """
+    digest = hashlib.blake2b(f"{rxn_id}:{seed}".encode(), digest_size=8).digest()
+    return int.from_bytes(digest, "big") & 0xFFFFFFFF
+
+
+def select_reactions(
+    df: pl.DataFrame,
+    *,
+    target_total: int,
+    seed: int,
+    mandatory_column: str,
+) -> pl.DataFrame:
+    """Return up to ``target_total`` rows, pinning all ``mandatory_column=True`` rows.
+
+    Edge cases (each short-circuits):
+    - empty input → return unchanged
+    - ``df.height <= target_total`` → return all rows sorted by rxn_id
+    - mandatory rows already exceed target → truncate mandatory deterministically
+    """
+    if df.height == 0:
+        return df
+
+    if df.height <= target_total:
+        return df.sort("rxn_id")
+
+    must_keep = df.filter(pl.col(mandatory_column))
+    candidates = df.filter(~pl.col(mandatory_column))
+
+    if must_keep.height >= target_total:
+        return must_keep.sort("rxn_id").head(target_total)
+
+    fill_count = target_total - must_keep.height
+
+    doc_freq = compute_mol_doc_freq(df)
+    idf = compute_idf(doc_freq, df.height)
+
+    anchor_mol_ids: set[str] = set()
+    for row in must_keep.iter_rows(named=True):
+        anchor_mol_ids |= _row_mol_ids(row)
+
+    score = score_candidates(candidates, anchor_mol_ids, idf)
+    tiebreak = pl.Series(
+        "_tiebreak",
+        [_tiebreak(rxn_id, seed) for rxn_id in candidates["rxn_id"].to_list()],
+        dtype=pl.UInt64,
+    )
+
+    selected = (
+        candidates.with_columns(score, tiebreak)
+        .sort(["score", "_tiebreak"], descending=[True, False])
+        .head(fill_count)
+        .drop(["score", "_tiebreak"])
+    )
+
+    return pl.concat([must_keep, selected]).sort("rxn_id")

--- a/tests/unit/test_select.py
+++ b/tests/unit/test_select.py
@@ -1,0 +1,168 @@
+"""Tests for the curated-subset selection stage (Stage 14)."""
+
+from __future__ import annotations
+
+import polars as pl
+
+from aichemy.preprocessing.select import (
+    compute_idf,
+    compute_mol_doc_freq,
+    select_reactions,
+)
+
+REACTION_SUBSET_SCHEMA = {
+    "rxn_id": pl.Utf8,
+    "reactants": pl.List(pl.Struct({"mol_id": pl.Utf8, "coefficient": pl.Float64})),
+    "products": pl.List(pl.Struct({"mol_id": pl.Utf8, "coefficient": pl.Float64})),
+    "rdkit_balanced": pl.Boolean,
+}
+
+
+def _stoich(mol_id: str, coeff: float = 1.0) -> dict:
+    return {"mol_id": mol_id, "coefficient": float(coeff)}
+
+
+def _row(rxn_id: str, reactants: list[str], products: list[str], *, rdkit_balanced: bool) -> dict:
+    return {
+        "rxn_id": rxn_id,
+        "reactants": [_stoich(m) for m in reactants],
+        "products": [_stoich(m) for m in products],
+        "rdkit_balanced": rdkit_balanced,
+    }
+
+
+def _make_df(rows: list[dict], extra_schema: dict | None = None) -> pl.DataFrame:
+    schema = dict(REACTION_SUBSET_SCHEMA)
+    if extra_schema:
+        schema.update(extra_schema)
+    return pl.DataFrame(rows, schema=schema)
+
+
+def test_empty_input_returns_empty() -> None:
+    df = _make_df([])
+    out = select_reactions(df, target_total=10, seed=42, mandatory_column="rdkit_balanced")
+    assert out.height == 0
+
+
+def test_total_below_target_returns_all() -> None:
+    rows = [
+        _row(f"r{i:03d}", ["A"], ["B"], rdkit_balanced=(i % 2 == 0)) for i in range(50)
+    ]
+    df = _make_df(rows)
+    out = select_reactions(df, target_total=100, seed=42, mandatory_column="rdkit_balanced")
+    assert out.height == 50
+    assert set(out["rxn_id"].to_list()) == {f"r{i:03d}" for i in range(50)}
+
+
+def test_must_keep_at_or_above_target_truncates() -> None:
+    rows = [_row(f"r{i:03d}", ["A"], ["B"], rdkit_balanced=True) for i in range(200)]
+    df = _make_df(rows)
+    out = select_reactions(df, target_total=100, seed=42, mandatory_column="rdkit_balanced")
+    assert out.height == 100
+    # Sorted by rxn_id → first 100 lex-sorted ids.
+    assert out["rxn_id"].to_list() == [f"r{i:03d}" for i in range(100)]
+
+
+def test_must_keep_all_present() -> None:
+    must_keep_ids = {"k0", "k1", "k2", "k3", "k4"}
+    rows = [_row(rid, ["A"], ["B"], rdkit_balanced=True) for rid in must_keep_ids]
+    rows += [
+        _row(f"c{i}", [f"X{i}"], [f"Y{i}"], rdkit_balanced=False) for i in range(20)
+    ]
+    df = _make_df(rows)
+    out = select_reactions(df, target_total=10, seed=42, mandatory_column="rdkit_balanced")
+    assert out.height == 10
+    assert must_keep_ids.issubset(set(out["rxn_id"].to_list()))
+
+
+def test_overlap_preferred_over_disjoint() -> None:
+    rows = [
+        _row("anchor", ["A", "B"], [], rdkit_balanced=True),
+        # Two candidates that share at least one mol_id with the anchor.
+        _row("overlap1", ["A"], ["P1"], rdkit_balanced=False),
+        _row("overlap2", ["B"], ["P2"], rdkit_balanced=False),
+        # Three disjoint candidates.
+        _row("disjoint1", ["X1"], ["Y1"], rdkit_balanced=False),
+        _row("disjoint2", ["X2"], ["Y2"], rdkit_balanced=False),
+        _row("disjoint3", ["X3"], ["Y3"], rdkit_balanced=False),
+    ]
+    df = _make_df(rows)
+    out = select_reactions(df, target_total=3, seed=42, mandatory_column="rdkit_balanced")
+    assert set(out["rxn_id"].to_list()) == {"anchor", "overlap1", "overlap2"}
+
+
+def test_tfidf_downweights_common_mol() -> None:
+    """A candidate sharing a RARE mol with the anchor beats one sharing a COMMON mol."""
+    rows = [
+        # Anchor references both A (common) and B (rare).
+        _row("anchor", ["A", "B"], [], rdkit_balanced=True),
+        # Candidate sharing only A (a common cofactor).
+        _row("cand_common", ["A"], ["P_common"], rdkit_balanced=False),
+        # Candidate sharing only B (a rare intermediate).
+        _row("cand_rare", ["B"], ["P_rare"], rdkit_balanced=False),
+    ]
+    # Inflate A's doc-frequency with filler reactions so idf(A) << idf(B).
+    rows += [
+        _row(f"filler{i}", ["A"], [f"Z{i}"], rdkit_balanced=False) for i in range(30)
+    ]
+    df = _make_df(rows)
+    # target_total = must_keep (1) + 1 fill = 2 → best single candidate must win.
+    out = select_reactions(df, target_total=2, seed=42, mandatory_column="rdkit_balanced")
+    assert out.height == 2
+    assert set(out["rxn_id"].to_list()) == {"anchor", "cand_rare"}
+
+
+def test_seeded_random_fills_score_zero_candidates() -> None:
+    """When all fill candidates have score=0, the seeded tiebreak makes the result deterministic."""
+    rows = [
+        _row("anchor", ["A"], ["B"], rdkit_balanced=True),
+    ]
+    rows += [
+        _row(f"c{i:03d}", [f"X{i}"], [f"Y{i}"], rdkit_balanced=False) for i in range(20)
+    ]
+    df = _make_df(rows)
+    out1 = select_reactions(df, target_total=5, seed=42, mandatory_column="rdkit_balanced")
+    out2 = select_reactions(df, target_total=5, seed=42, mandatory_column="rdkit_balanced")
+    assert out1.height == 5
+    assert out1["rxn_id"].to_list() == out2["rxn_id"].to_list()
+
+
+def test_mandatory_column_balanced() -> None:
+    """Switching mandatory_column to 'balanced' changes which rows are pinned."""
+    # Construct rows where rdkit_balanced and balanced disagree.
+    rows = [
+        {**_row("r0", ["A"], ["B"], rdkit_balanced=True), "balanced": False},
+        {**_row("r1", ["A"], ["B"], rdkit_balanced=False), "balanced": True},
+        {**_row("r2", ["A"], ["B"], rdkit_balanced=True), "balanced": True},
+        {**_row("r3", ["C"], ["D"], rdkit_balanced=False), "balanced": False},
+        {**_row("r4", ["E"], ["F"], rdkit_balanced=False), "balanced": False},
+    ]
+    df = _make_df(rows, extra_schema={"balanced": pl.Boolean})
+
+    # target_total = mandatory count means the function returns just the pinned set
+    # (must_keep.height >= target_total branch). This isolates the pinning mechanism
+    # from the fill ranking.
+    out_rdkit = select_reactions(df, target_total=2, seed=42, mandatory_column="rdkit_balanced")
+    out_balanced = select_reactions(df, target_total=2, seed=42, mandatory_column="balanced")
+
+    assert set(out_rdkit["rxn_id"].to_list()) == {"r0", "r2"}
+    assert set(out_balanced["rxn_id"].to_list()) == {"r1", "r2"}
+
+
+def test_compute_mol_doc_freq_dedupes_within_row() -> None:
+    rows = [
+        _row("r0", ["A", "A"], ["A", "B"], rdkit_balanced=True),  # mol A on both sides
+        _row("r1", ["B"], ["C"], rdkit_balanced=True),
+    ]
+    df = _make_df(rows)
+    doc_freq = compute_mol_doc_freq(df)
+    assert doc_freq == {"A": 1, "B": 2, "C": 1}
+
+
+def test_compute_idf_smoothing() -> None:
+    # n=10, df=10 → log(11/11) + 1 = 1.0
+    idf = compute_idf({"common": 10}, n_docs=10)
+    assert abs(idf["common"] - 1.0) < 1e-9
+    # Rare mol gets a higher idf.
+    idf2 = compute_idf({"rare": 1, "common": 10}, n_docs=10)
+    assert idf2["rare"] > idf2["common"]

--- a/tests/unit/test_select.py
+++ b/tests/unit/test_select.py
@@ -45,9 +45,7 @@ def test_empty_input_returns_empty() -> None:
 
 
 def test_total_below_target_returns_all() -> None:
-    rows = [
-        _row(f"r{i:03d}", ["A"], ["B"], rdkit_balanced=(i % 2 == 0)) for i in range(50)
-    ]
+    rows = [_row(f"r{i:03d}", ["A"], ["B"], rdkit_balanced=(i % 2 == 0)) for i in range(50)]
     df = _make_df(rows)
     out = select_reactions(df, target_total=100, seed=42, mandatory_column="rdkit_balanced")
     assert out.height == 50
@@ -66,9 +64,7 @@ def test_must_keep_at_or_above_target_truncates() -> None:
 def test_must_keep_all_present() -> None:
     must_keep_ids = {"k0", "k1", "k2", "k3", "k4"}
     rows = [_row(rid, ["A"], ["B"], rdkit_balanced=True) for rid in must_keep_ids]
-    rows += [
-        _row(f"c{i}", [f"X{i}"], [f"Y{i}"], rdkit_balanced=False) for i in range(20)
-    ]
+    rows += [_row(f"c{i}", [f"X{i}"], [f"Y{i}"], rdkit_balanced=False) for i in range(20)]
     df = _make_df(rows)
     out = select_reactions(df, target_total=10, seed=42, mandatory_column="rdkit_balanced")
     assert out.height == 10
@@ -102,9 +98,7 @@ def test_tfidf_downweights_common_mol() -> None:
         _row("cand_rare", ["B"], ["P_rare"], rdkit_balanced=False),
     ]
     # Inflate A's doc-frequency with filler reactions so idf(A) << idf(B).
-    rows += [
-        _row(f"filler{i}", ["A"], [f"Z{i}"], rdkit_balanced=False) for i in range(30)
-    ]
+    rows += [_row(f"filler{i}", ["A"], [f"Z{i}"], rdkit_balanced=False) for i in range(30)]
     df = _make_df(rows)
     # target_total = must_keep (1) + 1 fill = 2 → best single candidate must win.
     out = select_reactions(df, target_total=2, seed=42, mandatory_column="rdkit_balanced")
@@ -117,9 +111,7 @@ def test_seeded_random_fills_score_zero_candidates() -> None:
     rows = [
         _row("anchor", ["A"], ["B"], rdkit_balanced=True),
     ]
-    rows += [
-        _row(f"c{i:03d}", [f"X{i}"], [f"Y{i}"], rdkit_balanced=False) for i in range(20)
-    ]
+    rows += [_row(f"c{i:03d}", [f"X{i}"], [f"Y{i}"], rdkit_balanced=False) for i in range(20)]
     df = _make_df(rows)
     out1 = select_reactions(df, target_total=5, seed=42, mandatory_column="rdkit_balanced")
     out2 = select_reactions(df, target_total=5, seed=42, mandatory_column="rdkit_balanced")


### PR DESCRIPTION
## Summary

Inserts a new DVC stage `select_reactions` between `augment_directionality` and `export` that curates a 100k-row subset from the ~365k augmented reactions and feeds it forward as the canonical `data/processed/reactions.parquet` input.

Selection policy (matches the `/ultraplan` spec):

- **Pin** every row where `rdkit_balanced=True` (~40,874 on full data).
- **Fill** the remainder by ranking candidates on a smoothed TF-IDF score over mol_ids shared with the pinned set, so common cofactors (H₂O, ATP, NAD+, …) don't dominate.
- **Tiebreak** with a deterministic BLAKE2b hash seeded by config so reruns are bit-identical (Python's built-in `hash` is salted per process — would break reproducibility across DVC runs).
- **Edge cases** short-circuited: empty input, total ≤ target, and mandatory rows already exceeding target.

## Pipeline shape (after change)

```
augment_thermo → augment_directionality
                        ↓
                 select_reactions   ← NEW (data/interim/selected/reactions.parquet)
                        ↓
                      export → data/processed/reactions.parquet
```

`augment_prices` is unchanged. `export` now reads from `interim/selected/` rather than `interim/augmented/reactions_full.parquet`.

## Files changed

- `src/aichemy/preprocessing/select.py` — new module: `compute_mol_doc_freq`, `compute_idf`, `score_candidates`, `select_reactions`. Pure functions, no I/O.
- `src/aichemy/cli.py` — adds `aichemy select reactions` subcommand and switches `export` to read from `interim/selected/`.
- `src/aichemy/config.py` — adds `SelectionConfig(target_total, seed, mandatory_column)` wired into `PreprocessingConfig`.
- `configs/default.yaml` — `selection:` block (`target_total: 100000`, `seed: 42`, `mandatory_column: rdkit_balanced`).
- `dvc.yaml` — new `select_reactions` stage; `export` deps rewired.
- `tests/unit/test_select.py` — 10 tests covering the 8-test spec plus 2 helpers (doc-freq within-row de-dup, IDF smoothing).

## Test plan

- [x] `uv run pytest tests/unit/test_select.py -v` — 10/10 green
- [x] `uv run pytest tests/unit/` — no new failures (the 2 pre-existing `synrbl`-import failures are present on `main` too; orthogonal optional dependency)
- [x] `uv run ruff check` on changed files — clean
- [x] `uv run dvc dag select_reactions` / `uv run dvc dag export` — graph structure verified
- [x] `uv run aichemy select reactions --help` — CLI parses
- [ ] Full-data `dvc repro select_reactions` — requires real `data/` dir, run after merge. Expect ~100,000 rows out, ~40,874 with `rdkit_balanced=True`.

Follow-up to PRs #15 / #17 / #19.

---
_Generated by [Claude Code](https://claude.ai/code/session_018FqErdTQenG7g7r4c44y54)_