### PR TITLE
rollup: merge licensing-integration → main (full A→G feature)

### DIFF
--- a/docs/superpowers/specs/2026-04-25-aichemy-pricing-licensing-design.md
+++ b/docs/superpowers/specs/2026-04-25-aichemy-pricing-licensing-design.md
@@ -254,6 +254,7 @@ Full `dvc repro` on the existing tiny fixture (`tests/fixtures/`), with PatentsV
 3. **The patent associated with a reaction is the patent it was *extracted from*** (Lowe dataset provenance), not necessarily the patent that *legally protects* the route. A reaction might be prior art the patent merely cites. The LLM classifier mitigates this when the patent's claims clearly cover something else, but doesn't eliminate the issue.
 4. **Process royalty on intermediate-only reactions** uses implied market-price revenue rather than a per-unit-of-chemistry fee — a modeling choice rather than a fact about how license deals work.
 5. **Royalty rate range \[0%, 8%\] is industry-typical for fine/specialty chemistry** but actual deals vary widely. The sweep is intended to demonstrate decision robustness within this range, not predict the rate of any specific deal.
+6. **PatentsView v1 endpoint deprecated.** As of 2026-04, the entire `patentsview.org` host (root, `search.*`, `api.*`) returns 301-redirect to the USPTO ODP transition guide; PatentsView is retired. The fetch client now targets the USPTO Open Data Portal (`api.uspto.gov`), which requires a free API key in `USPTO_ODP_API_KEY`. ODP splits metadata and full text across two endpoints — abstract/claims are fetched per-patent from the grant XML (~2× the request count vs PatentsView v1). The captured ODP contract is documented inline on `_parse_response` in `src/aichemy/preprocessing/patents/fetch.py`.
 
 ## Out of scope
 

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -114,6 +114,49 @@ stages:
     outs:
       - data/interim/augmented/reactions_full.parquet
 
+  fetch_patent_metadata:
+    cmd: uv run aichemy patents fetch --config configs/default.yaml
+    deps:
+      - configs/default.yaml
+      - src/aichemy/preprocessing/patents/fetch.py
+      - data/interim/augmented/reactions_full.parquet
+    outs:
+      - data/interim/patents/patent_metadata.parquet
+
+  classify_licenses_cpc:
+    cmd: uv run aichemy patents classify-cpc --config configs/default.yaml
+    deps:
+      - configs/default.yaml
+      - configs/cpc_rules.yaml
+      - src/aichemy/preprocessing/patents/cpc.py
+      - data/interim/augmented/reactions_full.parquet
+      - data/interim/patents/patent_metadata.parquet
+    outs:
+      - data/interim/licenses/cpc_classifications.parquet
+
+  classify_licenses_llm:
+    cmd: uv run aichemy patents classify-llm --config configs/default.yaml
+    deps:
+      - configs/default.yaml
+      - src/aichemy/preprocessing/patents/llm_classify.py
+      - src/aichemy/preprocessing/patents/cache.py
+      - data/interim/licenses/cpc_classifications.parquet
+      - data/interim/patents/patent_metadata.parquet
+    outs:
+      - data/interim/licenses/llm_classifications.parquet
+      - data/interim/licenses/llm_cache.jsonl
+
+  augment_licenses:
+    cmd: uv run aichemy augment licenses --config configs/default.yaml
+    deps:
+      - configs/default.yaml
+      - src/aichemy/preprocessing/augment/licenses.py
+      - data/interim/augmented/reactions_full.parquet
+      - data/interim/licenses/cpc_classifications.parquet
+      - data/interim/licenses/llm_classifications.parquet
+    outs:
+      - data/interim/augmented/reactions_licensed.parquet
+
   augment_prices:
     cmd: uv run aichemy augment prices --config configs/default.yaml
     deps:
@@ -130,7 +173,7 @@ stages:
       - configs/default.yaml
       - src/aichemy/preprocessing/export.py
       - data/interim/augmented/molecules_priced.parquet
-      - data/interim/augmented/reactions_full.parquet
+      - data/interim/augmented/reactions_licensed.parquet
     outs:
       - data/processed/reactions.parquet
       - data/processed/molecules.parquet

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dev = [
     "nbstripout",
     "dvc>=3.0",
     "responses>=0.25",
+    "types-requests>=2.31",
 ]
 
 [tool.ruff]

--- a/src/aichemy/cli.py
+++ b/src/aichemy/cli.py
@@ -691,9 +691,7 @@ def patents_classify_llm(
     cfg = _load(config, override)
 
     if not os.environ.get("ANTHROPIC_API_KEY"):
-        raise typer.BadParameter(
-            "ANTHROPIC_API_KEY not set; LLM classification cannot proceed."
-        )
+        raise typer.BadParameter("ANTHROPIC_API_KEY not set; LLM classification cannot proceed.")
 
     cpc = pl.read_parquet(licenses_path(cfg, "cpc_classifications.parquet"))
     patents = pl.read_parquet(patents_path(cfg, "patent_metadata.parquet"))

--- a/src/aichemy/cli.py
+++ b/src/aichemy/cli.py
@@ -8,6 +8,7 @@ import typer
 from aichemy.config import PreprocessingConfig, load_config
 from aichemy.preprocessing import export as export_module
 from aichemy.preprocessing.augment import directionality as directionality_module
+from aichemy.preprocessing.augment import licenses as licenses_module
 from aichemy.preprocessing.augment import prices as prices_module
 from aichemy.preprocessing.augment import (
     prices_scrapers as _prices_scrapers,  # noqa: F401 — side effect: registers scrapers
@@ -612,6 +613,61 @@ def augment_directionality(
         augmented = df  # nothing to do without direction annotation
     write_reactions(augmented, output_path)
     typer.echo(f"[augment directionality] wrote {augmented.height} rows.")
+
+
+@augment_app.command("licenses")
+def augment_licenses_cmd(
+    config: Path = ConfigOpt,
+    override: list[Path] = OverrideOpt,
+) -> None:
+    """Merge CPC + LLM license classifications onto reactions."""
+    cfg = _load(config, override)
+    input_path = interim_path(cfg, "augmented", "reactions_full.parquet")
+    output_path = interim_path(cfg, "augmented", "reactions_licensed.parquet")
+
+    if not input_path.exists():
+        write_empty_reactions(output_path)
+        typer.echo(f"[augment licenses] upstream {input_path} missing; wrote empty parquet.")
+        return
+
+    reactions = read_reactions(input_path)
+    cpc_path = licenses_path(cfg, "cpc_classifications.parquet")
+    llm_path = licenses_path(cfg, "llm_classifications.parquet")
+
+    if cpc_path.exists():
+        cpc = pl.read_parquet(cpc_path)
+    else:
+        cpc = pl.DataFrame(
+            schema={
+                "rxn_id": pl.Utf8,
+                "patent_number": pl.Utf8,
+                "patent_active": pl.Boolean,
+                "cpc_ambiguous": pl.Boolean,
+                "process_covered_cpc": pl.Boolean,
+                "composition_covered_cpc": pl.Boolean,
+            }
+        )
+
+    if llm_path.exists():
+        llm = pl.read_parquet(llm_path)
+    else:
+        llm = pl.DataFrame(
+            schema={
+                "patent_number": pl.Utf8,
+                "process_covered": pl.Boolean,
+                "composition_covered": pl.Boolean,
+            }
+        )
+
+    out = licenses_module.augment_licenses(reactions, cpc, llm)
+    write_reactions(out, output_path)
+
+    n_proc = int(out["process_covered"].sum())
+    n_comp = int(out["composition_covered"].sum())
+    typer.echo(
+        f"[augment licenses] {out.height} reactions "
+        f"({n_proc} process-covered, {n_comp} composition-covered) → {output_path}"
+    )
 
 
 @patents_app.command("fetch")

--- a/src/aichemy/cli.py
+++ b/src/aichemy/cli.py
@@ -779,7 +779,7 @@ def export(
 ) -> None:
     """Write final unified hypergraph parquets + manifest.json to data/processed/."""
     cfg = _load(config, override)
-    reactions_in = interim_path(cfg, "augmented", "reactions_full.parquet")
+    reactions_in = interim_path(cfg, "augmented", "reactions_licensed.parquet")
     molecules_in = interim_path(cfg, "augmented", "molecules_priced.parquet")
     reactions_out = processed_path(cfg, "reactions.parquet")
     molecules_out = processed_path(cfg, "molecules.parquet")

--- a/src/aichemy/cli.py
+++ b/src/aichemy/cli.py
@@ -18,6 +18,7 @@ from aichemy.preprocessing.augment.directionality import DirectionalityMode
 from aichemy.preprocessing.balance import validate as balance_validate_module
 from aichemy.preprocessing.io import (
     interim_path,
+    licenses_path,
     patents_path,
     processed_path,
     raw_path,
@@ -642,6 +643,37 @@ def patents_fetch(
 
     n_ok = sum(1 for p in items if p.fetch_status == "ok")
     typer.echo(f"[patents fetch] wrote {len(items)} rows ({n_ok} ok) → {out_path}")
+
+
+@patents_app.command("classify-cpc")
+def patents_classify_cpc(
+    config: Path = ConfigOpt,
+    override: list[Path] = OverrideOpt,
+) -> None:
+    """Classify each (rxn_id, patent) pair via CPC-code rules."""
+    from datetime import date
+
+    from aichemy.preprocessing.patents.cpc import (
+        classify_dataframe,
+        load_cpc_rules,
+    )
+
+    cfg = _load(config, override)
+    reactions = read_reactions(interim_path(cfg, "augmented", "reactions_full.parquet"))
+    patents = pl.read_parquet(patents_path(cfg, "patent_metadata.parquet"))
+    rules = load_cpc_rules(cfg.licenses.cpc_rules_path)
+
+    out = classify_dataframe(reactions, patents, rules=rules, today=date.today())
+    out_path = licenses_path(cfg, "cpc_classifications.parquet")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out.write_parquet(out_path)
+
+    n_ambig = int(out["cpc_ambiguous"].sum())
+    n_active = int(out["patent_active"].sum())
+    typer.echo(
+        f"[patents classify-cpc] {out.height} rows "
+        f"({n_active} active, {n_ambig} ambiguous → LLM) → {out_path}"
+    )
 
 
 @app.command("export")

--- a/src/aichemy/cli.py
+++ b/src/aichemy/cli.py
@@ -676,6 +676,48 @@ def patents_classify_cpc(
     )
 
 
+@patents_app.command("classify-llm")
+def patents_classify_llm(
+    config: Path = ConfigOpt,
+    override: list[Path] = OverrideOpt,
+) -> None:
+    """Eagerly classify CPC-ambiguous active patents via Claude; cache results."""
+    import os
+
+    import anthropic
+
+    from aichemy.preprocessing.patents.llm_classify import classify_ambiguous_patents
+
+    cfg = _load(config, override)
+
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        raise typer.BadParameter(
+            "ANTHROPIC_API_KEY not set; LLM classification cannot proceed."
+        )
+
+    cpc = pl.read_parquet(licenses_path(cfg, "cpc_classifications.parquet"))
+    patents = pl.read_parquet(patents_path(cfg, "patent_metadata.parquet"))
+    reactions = read_reactions(interim_path(cfg, "augmented", "reactions_full.parquet"))
+
+    client = anthropic.Anthropic()
+    out_path = licenses_path(cfg, "llm_classifications.parquet")
+    out = classify_ambiguous_patents(
+        cpc=cpc,
+        patents=patents,
+        reactions=reactions,
+        cache_path=cfg.licenses.cache_path,
+        out_path=out_path,
+        client=client,
+        model=cfg.licenses.llm_model,
+        max_retries=cfg.licenses.llm_max_retries,
+    )
+    n_hit = int(out["cache_hit"].sum())
+    typer.echo(
+        f"[patents classify-llm] {out.height} patents classified "
+        f"({n_hit} cache hits, {out.height - n_hit} fresh) → {out_path}"
+    )
+
+
 @app.command("export")
 def export(
     config: Path = ConfigOpt,

--- a/src/aichemy/cli.py
+++ b/src/aichemy/cli.py
@@ -18,6 +18,7 @@ from aichemy.preprocessing.augment.directionality import DirectionalityMode
 from aichemy.preprocessing.balance import validate as balance_validate_module
 from aichemy.preprocessing.io import (
     interim_path,
+    patents_path,
     processed_path,
     raw_path,
     read_molecules,
@@ -34,10 +35,12 @@ ingest_app = typer.Typer(help="Ingest raw data from a source.")
 dedup_app = typer.Typer(help="Deduplicate molecules or reactions.")
 balance_app = typer.Typer(help="Balance and validate reaction atom counts.")
 augment_app = typer.Typer(help="Enrich the merged table with yields, prices, directionality.")
+patents_app = typer.Typer(help="Patent metadata fetching and license classification.")
 app.add_typer(ingest_app, name="ingest")
 app.add_typer(dedup_app, name="dedup")
 app.add_typer(balance_app, name="balance")
 app.add_typer(augment_app, name="augment")
+app.add_typer(patents_app, name="patents")
 app.add_typer(solver_app, name="solve")
 
 
@@ -608,6 +611,37 @@ def augment_directionality(
         augmented = df  # nothing to do without direction annotation
     write_reactions(augmented, output_path)
     typer.echo(f"[augment directionality] wrote {augmented.height} rows.")
+
+
+@patents_app.command("fetch")
+def patents_fetch(
+    config: Path = ConfigOpt,
+    override: list[Path] = OverrideOpt,
+) -> None:
+    """Fetch PatentsView metadata for every USPTO patent referenced by reactions."""
+    from aichemy.preprocessing.patents.fetch import (
+        fetch_patents,
+        write_metadata_parquet,
+    )
+
+    cfg = _load(config, override)
+    reactions = read_reactions(interim_path(cfg, "augmented", "reactions_full.parquet"))
+
+    uspto_rxns = reactions.filter(pl.col("source") == "uspto")
+    patent_numbers = sorted({rid.split(":")[1] for rid in uspto_rxns["rxn_id"].to_list()})
+    typer.echo(f"[patents fetch] {len(patent_numbers)} unique USPTO patents to fetch")
+
+    items = fetch_patents(
+        patent_numbers,
+        endpoint=cfg.licenses.patentsview_endpoint,
+        max_retries=cfg.licenses.fetch_max_retries,
+        batch_size=cfg.licenses.fetch_batch_size,
+    )
+    out_path = patents_path(cfg, "patent_metadata.parquet")
+    write_metadata_parquet(items, out_path)
+
+    n_ok = sum(1 for p in items if p.fetch_status == "ok")
+    typer.echo(f"[patents fetch] wrote {len(items)} rows ({n_ok} ok) → {out_path}")
 
 
 @app.command("export")

--- a/src/aichemy/cli.py
+++ b/src/aichemy/cli.py
@@ -675,11 +675,22 @@ def patents_fetch(
     config: Path = ConfigOpt,
     override: list[Path] = OverrideOpt,
 ) -> None:
-    """Fetch PatentsView metadata for every USPTO patent referenced by reactions."""
+    """Fetch USPTO ODP metadata for every USPTO patent referenced by reactions."""
+    import os
+
     from aichemy.preprocessing.patents.fetch import (
+        API_KEY_ENV,
         fetch_patents,
         write_metadata_parquet,
     )
+
+    if not os.environ.get(API_KEY_ENV):
+        typer.echo(
+            f"[patents fetch] {API_KEY_ENV} env var is required "
+            "(get a free key at https://developer.uspto.gov)",
+            err=True,
+        )
+        raise typer.Exit(1)
 
     cfg = _load(config, override)
     reactions = read_reactions(interim_path(cfg, "augmented", "reactions_full.parquet"))

--- a/src/aichemy/config.py
+++ b/src/aichemy/config.py
@@ -41,7 +41,7 @@ class YieldConfig(BaseModel):
 class LicensesConfig(BaseModel):
     model_config = {"extra": "forbid"}
 
-    patentsview_endpoint: str = "https://search.patentsview.org/api/v1/patent"
+    patentsview_endpoint: str = "https://api.uspto.gov/api/v1/patent/applications/search"
     cpc_rules_path: Path = Field(default_factory=lambda: Path("configs/cpc_rules.yaml"))
     cache_path: Path = Field(default_factory=lambda: Path("data/interim/licenses/llm_cache.jsonl"))
     llm_model: str = "claude-haiku-4-5"

--- a/src/aichemy/preprocessing/augment/licenses.py
+++ b/src/aichemy/preprocessing/augment/licenses.py
@@ -1,0 +1,56 @@
+"""Merge license classifications onto reactions (Task 14).
+
+Resolution rule (per `(rxn_id, patent_number)` pair):
+- If `cpc_ambiguous` AND a matching LLM row exists → use LLM verdict.
+- Else → use the CPC verdict.
+
+Then OR-aggregate per `rxn_id` (a reaction with multiple patents — not
+currently produced by upstream stages, but supported by this schema — gets
+the OR across patents). Finally left-join onto the full reactions DataFrame
+so MetaNetX rows (no patent association) end up with all flags False via
+`fill_null(False)`.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+
+def augment_licenses(
+    reactions: pl.DataFrame,
+    cpc: pl.DataFrame,
+    llm: pl.DataFrame,
+) -> pl.DataFrame:
+    """Add patent_active, process_covered, composition_covered columns to reactions."""
+    llm_renamed = llm.select(
+        "patent_number",
+        pl.col("process_covered").alias("process_covered_llm"),
+        pl.col("composition_covered").alias("composition_covered_llm"),
+    )
+
+    resolved = (
+        cpc.join(llm_renamed, on="patent_number", how="left")
+        .with_columns(
+            pl.when(pl.col("cpc_ambiguous") & pl.col("process_covered_llm").is_not_null())
+            .then(pl.col("process_covered_llm"))
+            .otherwise(pl.col("process_covered_cpc"))
+            .alias("process_covered"),
+            pl.when(pl.col("cpc_ambiguous") & pl.col("composition_covered_llm").is_not_null())
+            .then(pl.col("composition_covered_llm"))
+            .otherwise(pl.col("composition_covered_cpc"))
+            .alias("composition_covered"),
+        )
+        .select("rxn_id", "patent_active", "process_covered", "composition_covered")
+    )
+
+    aggregated = resolved.group_by("rxn_id").agg(
+        pl.col("patent_active").any().alias("patent_active"),
+        pl.col("process_covered").any().alias("process_covered"),
+        pl.col("composition_covered").any().alias("composition_covered"),
+    )
+
+    return reactions.join(aggregated, on="rxn_id", how="left").with_columns(
+        pl.col("patent_active").fill_null(False),
+        pl.col("process_covered").fill_null(False),
+        pl.col("composition_covered").fill_null(False),
+    )

--- a/src/aichemy/preprocessing/patents/__init__.py
+++ b/src/aichemy/preprocessing/patents/__init__.py
@@ -1,0 +1,1 @@
+"""Patent metadata fetching and license classification."""

--- a/src/aichemy/preprocessing/patents/cache.py
+++ b/src/aichemy/preprocessing/patents/cache.py
@@ -1,0 +1,48 @@
+"""JSONL append-only cache for LLM patent classifications.
+
+One entry per LLM call. Cache key is `patent_number`. PatentsView is
+canonical (abstract/claims for a given patent_number are stable), so the
+cache hit on `patent_number` alone is correct.
+
+Append-only design means the file is human-readable, easy to inspect, and
+each invocation extends the file rather than rewriting it. On read, later
+entries with the same `patent_number` win.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+@dataclass
+class LLMCacheEntry:
+    patent_number: str
+    process_covered: bool
+    composition_covered: bool
+    confidence: float
+    rationale: str
+    model: str
+    ts: str
+
+
+def load_cache(path: Path) -> dict[str, LLMCacheEntry]:
+    """Read cache; later entries with the same patent_number win."""
+    if not path.exists():
+        return {}
+    out: dict[str, LLMCacheEntry] = {}
+    with open(path) as f:
+        for raw_line in f:
+            line = raw_line.strip()
+            if not line:
+                continue
+            data = json.loads(line)
+            out[data["patent_number"]] = LLMCacheEntry(**data)
+    return out
+
+
+def append_cache(path: Path, entry: LLMCacheEntry) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a") as f:
+        f.write(json.dumps(asdict(entry)) + "\n")

--- a/src/aichemy/preprocessing/patents/cpc.py
+++ b/src/aichemy/preprocessing/patents/cpc.py
@@ -1,0 +1,149 @@
+"""CPC-code classifier for patent licensing.
+
+Pure function operating on a single patent's CPC codes + filing date,
+producing booleans that downstream stages consume. Rules are loaded from
+a YAML config so they can be tweaked without code changes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+
+import polars as pl
+import yaml
+
+PATENT_TERM_YEARS = 20
+
+
+@dataclass
+class CPCRules:
+    process_codes: list[str]
+    composition_codes: list[str]
+    ambiguous_codes: list[str]
+
+
+@dataclass
+class CPCClassification:
+    patent_active: bool
+    cpc_process_hit: bool
+    cpc_composition_hit: bool
+    cpc_ambiguous: bool
+    process_covered_cpc: bool
+    composition_covered_cpc: bool
+
+
+CPC_CLASSIFICATION_SCHEMA = {
+    "rxn_id": pl.Utf8,
+    "patent_number": pl.Utf8,
+    "patent_active": pl.Boolean,
+    "cpc_process_hit": pl.Boolean,
+    "cpc_composition_hit": pl.Boolean,
+    "cpc_ambiguous": pl.Boolean,
+    "process_covered_cpc": pl.Boolean,
+    "composition_covered_cpc": pl.Boolean,
+}
+
+
+def load_cpc_rules(path: Path) -> CPCRules:
+    with open(path) as f:
+        raw = yaml.safe_load(f) or {}
+    return CPCRules(
+        process_codes=list(raw.get("process_codes") or []),
+        composition_codes=list(raw.get("composition_codes") or []),
+        ambiguous_codes=list(raw.get("ambiguous_codes") or []),
+    )
+
+
+def classify_patent(
+    *,
+    cpc_codes: list[str],
+    filing_date_str: str | None,
+    today: date,
+    rules: CPCRules,
+) -> CPCClassification:
+    """Classify one patent. Inactive patents short-circuit to all-False."""
+    patent_active = _is_active(filing_date_str, today)
+    if not patent_active:
+        return CPCClassification(
+            patent_active=False,
+            cpc_process_hit=False,
+            cpc_composition_hit=False,
+            cpc_ambiguous=False,
+            process_covered_cpc=False,
+            composition_covered_cpc=False,
+        )
+
+    process_hit = _any_prefix_match(cpc_codes, rules.process_codes)
+    composition_hit = _any_prefix_match(cpc_codes, rules.composition_codes)
+    ambiguous_explicit = _any_prefix_match(cpc_codes, rules.ambiguous_codes)
+    has_any_chemistry = process_hit or composition_hit or ambiguous_explicit
+
+    ambiguous = ambiguous_explicit or (process_hit and composition_hit) or not has_any_chemistry
+
+    return CPCClassification(
+        patent_active=True,
+        cpc_process_hit=process_hit,
+        cpc_composition_hit=composition_hit,
+        cpc_ambiguous=ambiguous,
+        process_covered_cpc=process_hit and not ambiguous,
+        composition_covered_cpc=composition_hit and not ambiguous,
+    )
+
+
+def _any_prefix_match(codes: list[str], prefixes: list[str]) -> bool:
+    return any(c.startswith(p) for c in codes for p in prefixes)
+
+
+def _is_active(filing_date_str: str | None, today: date) -> bool:
+    if not filing_date_str:
+        return False
+    try:
+        filed = date.fromisoformat(filing_date_str)
+    except ValueError:
+        return False
+    expiry = date(filed.year + PATENT_TERM_YEARS, filed.month, filed.day)
+    return today < expiry
+
+
+def classify_dataframe(
+    reactions: pl.DataFrame,
+    patents: pl.DataFrame,
+    *,
+    rules: CPCRules,
+    today: date,
+) -> pl.DataFrame:
+    """Produce one row per (rxn_id, patent_number) for USPTO reactions."""
+    uspto = reactions.filter(pl.col("source") == "uspto")
+    rxn_rows = []
+    for rid in uspto["rxn_id"].to_list():
+        parts = rid.split(":")
+        if len(parts) >= 3 and parts[0] == "USPTO":
+            rxn_rows.append({"rxn_id": rid, "patent_number": parts[1]})
+    rxn_df = pl.DataFrame(rxn_rows, schema={"rxn_id": pl.Utf8, "patent_number": pl.Utf8})
+
+    joined = rxn_df.join(patents, on="patent_number", how="left")
+
+    out_rows: list[dict] = []
+    for r in joined.iter_rows(named=True):
+        cpc_codes = list(r.get("cpc_codes") or [])
+        c = classify_patent(
+            cpc_codes=cpc_codes,
+            filing_date_str=r.get("filing_date"),
+            today=today,
+            rules=rules,
+        )
+        out_rows.append(
+            {
+                "rxn_id": r["rxn_id"],
+                "patent_number": r["patent_number"],
+                "patent_active": c.patent_active,
+                "cpc_process_hit": c.cpc_process_hit,
+                "cpc_composition_hit": c.cpc_composition_hit,
+                "cpc_ambiguous": c.cpc_ambiguous,
+                "process_covered_cpc": c.process_covered_cpc,
+                "composition_covered_cpc": c.composition_covered_cpc,
+            }
+        )
+    return pl.DataFrame(out_rows, schema=CPC_CLASSIFICATION_SCHEMA)

--- a/src/aichemy/preprocessing/patents/cpc.py
+++ b/src/aichemy/preprocessing/patents/cpc.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
+from typing import Any
 
 import polars as pl
 import yaml
@@ -125,7 +126,7 @@ def classify_dataframe(
 
     joined = rxn_df.join(patents, on="patent_number", how="left")
 
-    out_rows: list[dict] = []
+    out_rows: list[dict[str, Any]] = []
     for r in joined.iter_rows(named=True):
         cpc_codes = list(r.get("cpc_codes") or [])
         c = classify_patent(

--- a/src/aichemy/preprocessing/patents/fetch.py
+++ b/src/aichemy/preprocessing/patents/fetch.py
@@ -11,6 +11,7 @@ import logging
 import time
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import polars as pl
 import requests
@@ -30,7 +31,7 @@ class PatentMetadata:
     fetch_status: str  # "ok" | "not_found" | "error"
 
 
-PATENT_METADATA_SCHEMA = {
+PATENT_METADATA_SCHEMA: dict[str, Any] = {
     "patent_number": pl.Utf8,
     "filing_date": pl.Utf8,
     "grant_date": pl.Utf8,
@@ -108,7 +109,7 @@ def _fetch_batch(
     return [_error_record(pn) for pn in batch]
 
 
-def _parse_response(body: dict, batch: list[str]) -> list[PatentMetadata]:
+def _parse_response(body: dict[str, Any], batch: list[str]) -> list[PatentMetadata]:
     by_id: dict[str, PatentMetadata] = {}
     for p in body.get("patents") or []:
         pn = str(p.get("patent_number"))

--- a/src/aichemy/preprocessing/patents/fetch.py
+++ b/src/aichemy/preprocessing/patents/fetch.py
@@ -1,0 +1,180 @@
+"""PatentsView REST client.
+
+Fetches patent metadata (filing date, abstract, claims, CPC codes) for the
+USPTO patent numbers extracted from reaction `rxn_id`s. Used by the
+`fetch_patent_metadata` DVC stage.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import polars as pl
+import requests
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class PatentMetadata:
+    patent_number: str
+    filing_date: str | None
+    grant_date: str | None
+    abstract: str | None
+    claims_text: str | None
+    cpc_codes: list[str]
+    assignee: str | None
+    fetch_status: str  # "ok" | "not_found" | "error"
+
+
+PATENT_METADATA_SCHEMA = {
+    "patent_number": pl.Utf8,
+    "filing_date": pl.Utf8,
+    "grant_date": pl.Utf8,
+    "abstract": pl.Utf8,
+    "claims_text": pl.Utf8,
+    "cpc_codes": pl.List(pl.Utf8),
+    "assignee": pl.Utf8,
+    "fetch_status": pl.Utf8,
+}
+
+
+def fetch_patents(
+    patent_numbers: list[str],
+    *,
+    endpoint: str,
+    max_retries: int = 3,
+    batch_size: int = 25,
+    backoff_seconds: float = 1.0,
+) -> list[PatentMetadata]:
+    """Fetch metadata for the given patent numbers.
+
+    PatentsView accepts a JSON POST with a query in its query DSL. We batch
+    requests to amortize round-trip cost, retry on transient errors, and
+    record `fetch_status="error"` on permanent failure (rather than raise,
+    so the pipeline doesn't crash).
+    """
+    out: list[PatentMetadata] = []
+    seen: set[str] = set()
+    for i in range(0, len(patent_numbers), batch_size):
+        batch = patent_numbers[i : i + batch_size]
+        results = _fetch_batch(batch, endpoint, max_retries, backoff_seconds)
+        for r in results:
+            seen.add(r.patent_number)
+            out.append(r)
+    for pn in patent_numbers:
+        if pn not in seen:
+            out.append(_error_record(pn))
+    return out
+
+
+def _fetch_batch(
+    batch: list[str],
+    endpoint: str,
+    max_retries: int,
+    backoff_seconds: float,
+) -> list[PatentMetadata]:
+    payload = {
+        "q": {"patent_number": batch},
+        "f": [
+            "patent_number",
+            "patent_date",
+            "patent_abstract",
+            "claims",
+            "cpcs",
+            "assignees",
+            "application",
+        ],
+        "o": {"per_page": len(batch)},
+    }
+    for attempt in range(max_retries):
+        try:
+            r = requests.post(endpoint, json=payload, timeout=30)
+            if r.status_code == 200:
+                return _parse_response(r.json(), batch)
+            if r.status_code in (429, 500, 502, 503, 504) and attempt < max_retries - 1:
+                time.sleep(backoff_seconds * (2**attempt))
+                continue
+            log.warning("PatentsView returned %s for batch=%s", r.status_code, batch[:3])
+            break
+        except requests.RequestException as exc:
+            log.warning("PatentsView request failed (attempt %d): %s", attempt + 1, exc)
+            if attempt < max_retries - 1:
+                time.sleep(backoff_seconds * (2**attempt))
+                continue
+    return [_error_record(pn) for pn in batch]
+
+
+def _parse_response(body: dict, batch: list[str]) -> list[PatentMetadata]:
+    by_id: dict[str, PatentMetadata] = {}
+    for p in body.get("patents") or []:
+        pn = str(p.get("patent_number"))
+        claims_text = " ".join(c.get("text", "") for c in (p.get("claims") or []))
+        cpc_codes = [c.get("cpc_group_id", "") for c in (p.get("cpcs") or [])]
+        cpc_codes = [c for c in cpc_codes if c]
+        assignees = p.get("assignees") or []
+        assignee = assignees[0].get("assignee_organization") if assignees else None
+        application = p.get("application") or {}
+        by_id[pn] = PatentMetadata(
+            patent_number=pn,
+            filing_date=application.get("filing_date"),
+            grant_date=p.get("patent_date"),
+            abstract=p.get("patent_abstract"),
+            claims_text=claims_text or None,
+            cpc_codes=cpc_codes,
+            assignee=assignee,
+            fetch_status="ok",
+        )
+    out: list[PatentMetadata] = []
+    for pn in batch:
+        if pn in by_id:
+            out.append(by_id[pn])
+        else:
+            out.append(
+                PatentMetadata(
+                    patent_number=pn,
+                    filing_date=None,
+                    grant_date=None,
+                    abstract=None,
+                    claims_text=None,
+                    cpc_codes=[],
+                    assignee=None,
+                    fetch_status="not_found",
+                )
+            )
+    return out
+
+
+def _error_record(patent_number: str) -> PatentMetadata:
+    return PatentMetadata(
+        patent_number=patent_number,
+        filing_date=None,
+        grant_date=None,
+        abstract=None,
+        claims_text=None,
+        cpc_codes=[],
+        assignee=None,
+        fetch_status="error",
+    )
+
+
+def write_metadata_parquet(items: list[PatentMetadata], path: Path) -> None:
+    rows = [
+        {
+            "patent_number": p.patent_number,
+            "filing_date": p.filing_date,
+            "grant_date": p.grant_date,
+            "abstract": p.abstract,
+            "claims_text": p.claims_text,
+            "cpc_codes": p.cpc_codes,
+            "assignee": p.assignee,
+            "fetch_status": p.fetch_status,
+        }
+        for p in items
+    ]
+    df = pl.DataFrame(rows, schema=PATENT_METADATA_SCHEMA)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df.write_parquet(path)

--- a/src/aichemy/preprocessing/patents/fetch.py
+++ b/src/aichemy/preprocessing/patents/fetch.py
@@ -30,6 +30,18 @@ log = logging.getLogger(__name__)
 
 API_KEY_ENV = "USPTO_ODP_API_KEY"
 
+_GRANT_AUTH_ERROR_STATUSES = frozenset({401, 403, 429})
+
+
+class GrantFetchError(Exception):
+    """Raised by _fetch_grant_xml when the server returns an auth/rate-limit error.
+
+    HTTP 401, 403, or 429 from either the file-location lookup or the
+    signed-URL download are unrecoverable without operator action (bad key,
+    insufficient permissions, or quota exhausted), so they propagate up to
+    _fetch_batch which sets fetch_status="error" on the parent record.
+    """
+
 
 @dataclass
 class PatentMetadata:
@@ -118,7 +130,16 @@ def _fetch_batch(
                     )
                     if not file_uri:
                         continue
-                    xml = _fetch_grant_xml(file_uri, api_key)
+                    try:
+                        xml = _fetch_grant_xml(file_uri, api_key)
+                    except GrantFetchError as exc:
+                        log.warning(
+                            "Grant XML auth/rate-limit error for %s: %s",
+                            rec.patent_number,
+                            exc,
+                        )
+                        rec.fetch_status = "error"
+                        continue
                     if xml is None:
                         continue
                     abstract, claims_text = _parse_grant_xml(xml)
@@ -235,8 +256,15 @@ def _fetch_grant_xml(file_uri: str, api_key: str) -> str | None:
             no ``Location`` header — both shapes are handled.
       2. GET <signed-url>  (no auth header)
          -> 200, full grant XML
-    Returns the XML body, or None on any failure (caller treats this as
-    no-abstract/no-claims; metadata still counts as fetched).
+
+    Returns the XML body on success, or None when the grant XML is genuinely
+    absent (no signed URL in response, non-auth non-200 on signed download).
+    Callers should keep fetch_status="ok" in that case — it is data absence,
+    not an API error.
+
+    Raises GrantFetchError for HTTP 401/403/429 from either step — these
+    indicate a bad/expired key, insufficient permissions, or exhausted quota
+    and require operator action; the caller should set fetch_status="error".
     """
     try:
         r = requests.get(
@@ -245,6 +273,10 @@ def _fetch_grant_xml(file_uri: str, api_key: str) -> str | None:
             timeout=30,
             allow_redirects=False,
         )
+        if r.status_code in _GRANT_AUTH_ERROR_STATUSES:
+            raise GrantFetchError(
+                f"file-location lookup returned HTTP {r.status_code}"
+            )
         signed_url = r.headers.get("Location")
         if not signed_url:
             m = re.search(r"https://data\.uspto\.gov/[^\s\"]+", r.text)
@@ -256,10 +288,16 @@ def _fetch_grant_xml(file_uri: str, api_key: str) -> str | None:
                 return None
             signed_url = m.group(0).rstrip(".")
         rr = requests.get(signed_url, timeout=60)
+        if rr.status_code in _GRANT_AUTH_ERROR_STATUSES:
+            raise GrantFetchError(
+                f"signed-URL download returned HTTP {rr.status_code}"
+            )
         if rr.status_code != 200:
             log.warning("Grant XML download returned %s", rr.status_code)
             return None
         return rr.text
+    except GrantFetchError:
+        raise
     except requests.RequestException as exc:
         log.warning("Grant XML fetch failed: %s", exc)
         return None

--- a/src/aichemy/preprocessing/patents/fetch.py
+++ b/src/aichemy/preprocessing/patents/fetch.py
@@ -1,13 +1,23 @@
-"""PatentsView REST client.
+"""USPTO Open Data Portal (ODP) REST client.
 
 Fetches patent metadata (filing date, abstract, claims, CPC codes) for the
 USPTO patent numbers extracted from reaction `rxn_id`s. Used by the
 `fetch_patent_metadata` DVC stage.
+
+PatentsView (search.patentsview.org and api.patentsview.org) was retired in
+April 2026 — every path now 301-redirects to the USPTO ODP transition guide.
+This module targets the ODP at api.uspto.gov, which requires a free API key
+(signup at developer.uspto.gov, supply via the ``USPTO_ODP_API_KEY`` env
+var). ODP splits metadata and full text across two endpoints — search returns
+metadata + a per-record ``fileLocationURI``, which is downloaded separately
+(two-step: auth'd indirection + signed URL) and parsed for abstract/claims.
 """
 
 from __future__ import annotations
 
 import logging
+import os
+import re
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -17,6 +27,8 @@ import polars as pl
 import requests
 
 log = logging.getLogger(__name__)
+
+API_KEY_ENV = "USPTO_ODP_API_KEY"
 
 
 @dataclass
@@ -47,22 +59,33 @@ def fetch_patents(
     patent_numbers: list[str],
     *,
     endpoint: str,
+    api_key: str | None = None,
     max_retries: int = 3,
     batch_size: int = 25,
     backoff_seconds: float = 1.0,
 ) -> list[PatentMetadata]:
-    """Fetch metadata for the given patent numbers.
+    """Fetch metadata for the given patent numbers from the USPTO ODP.
 
-    PatentsView accepts a JSON POST with a query in its query DSL. We batch
-    requests to amortize round-trip cost, retry on transient errors, and
-    record `fetch_status="error"` on permanent failure (rather than raise,
-    so the pipeline doesn't crash).
+    Each batch is one Lucene OR-query against the ODP search endpoint; each
+    hit triggers a follow-up two-step grant-XML download for abstract/claims.
+    Returns one ``PatentMetadata`` per input number, with status:
+      - ``"ok"``        — search hit + (optional) XML parsed
+      - ``"not_found"`` — search returned no record for that number
+      - ``"error"``     — search retries exhausted on a permanent failure
     """
+    if api_key is None:
+        api_key = os.environ.get(API_KEY_ENV)
+    if not api_key:
+        raise RuntimeError(
+            f"{API_KEY_ENV} is not set; obtain a free key at "
+            "https://developer.uspto.gov and export it before running"
+        )
+
     out: list[PatentMetadata] = []
     seen: set[str] = set()
     for i in range(0, len(patent_numbers), batch_size):
         batch = patent_numbers[i : i + batch_size]
-        results = _fetch_batch(batch, endpoint, max_retries, backoff_seconds)
+        results = _fetch_batch(batch, endpoint, api_key, max_retries, backoff_seconds)
         for r in results:
             seen.add(r.patent_number)
             out.append(r)
@@ -75,78 +98,212 @@ def fetch_patents(
 def _fetch_batch(
     batch: list[str],
     endpoint: str,
+    api_key: str,
     max_retries: int,
     backoff_seconds: float,
 ) -> list[PatentMetadata]:
-    payload = {
-        "q": {"patent_number": batch},
-        "f": [
-            "patent_number",
-            "patent_date",
-            "patent_abstract",
-            "claims",
-            "cpcs",
-            "assignees",
-            "application",
-        ],
-        "o": {"per_page": len(batch)},
-    }
+    q = "applicationMetaData.patentNumber:(" + " OR ".join(batch) + ")"
+    headers = {"X-API-Key": api_key, "Accept": "application/json"}
+    params = {"q": q, "limit": str(len(batch))}
     for attempt in range(max_retries):
         try:
-            r = requests.post(endpoint, json=payload, timeout=30)
+            r = requests.get(endpoint, params=params, headers=headers, timeout=30)
             if r.status_code == 200:
-                return _parse_response(r.json(), batch)
+                pairs = _parse_response(r.json(), batch)
+                for rec, raw in pairs:
+                    if rec.fetch_status != "ok":
+                        continue
+                    file_uri = (raw.get("grantDocumentMetaData") or {}).get(
+                        "fileLocationURI"
+                    )
+                    if not file_uri:
+                        continue
+                    xml = _fetch_grant_xml(file_uri, api_key)
+                    if xml is None:
+                        continue
+                    abstract, claims_text = _parse_grant_xml(xml)
+                    rec.abstract = abstract
+                    rec.claims_text = claims_text
+                return [rec for rec, _ in pairs]
+            if r.status_code == 404:
+                # ODP returns 404 with "No matching records found" — treat the
+                # whole batch as not_found rather than retry.
+                return [_not_found_record(pn) for pn in batch]
             if r.status_code in (429, 500, 502, 503, 504) and attempt < max_retries - 1:
                 time.sleep(backoff_seconds * (2**attempt))
                 continue
-            log.warning("PatentsView returned %s for batch=%s", r.status_code, batch[:3])
+            log.warning("ODP search returned %s for batch=%s", r.status_code, batch[:3])
             break
         except requests.RequestException as exc:
-            log.warning("PatentsView request failed (attempt %d): %s", attempt + 1, exc)
+            log.warning("ODP search request failed (attempt %d): %s", attempt + 1, exc)
             if attempt < max_retries - 1:
                 time.sleep(backoff_seconds * (2**attempt))
                 continue
     return [_error_record(pn) for pn in batch]
 
 
-def _parse_response(body: dict[str, Any], batch: list[str]) -> list[PatentMetadata]:
-    by_id: dict[str, PatentMetadata] = {}
-    for p in body.get("patents") or []:
-        pn = str(p.get("patent_number"))
-        claims_text = " ".join(c.get("text", "") for c in (p.get("claims") or []))
-        cpc_codes = [c.get("cpc_group_id", "") for c in (p.get("cpcs") or [])]
-        cpc_codes = [c for c in cpc_codes if c]
-        assignees = p.get("assignees") or []
-        assignee = assignees[0].get("assignee_organization") if assignees else None
-        application = p.get("application") or {}
-        by_id[pn] = PatentMetadata(
-            patent_number=pn,
-            filing_date=application.get("filing_date"),
-            grant_date=p.get("patent_date"),
-            abstract=p.get("patent_abstract"),
-            claims_text=claims_text or None,
-            cpc_codes=cpc_codes,
-            assignee=assignee,
-            fetch_status="ok",
+def _parse_response(
+    body: dict[str, Any], batch: list[str]
+) -> list[tuple[PatentMetadata, dict[str, Any]]]:
+    """Map a USPTO ODP search response to (PatentMetadata, raw_record) pairs.
+
+    Captured contract (curl, 2026-04-26, against api.uspto.gov):
+      body = {
+        "count": int,
+        "patentFileWrapperDataBag": [{
+          "applicationNumberText": str,
+          "applicationMetaData": {
+            "patentNumber": str | null,
+            "grantDate": str | null,         # YYYY-MM-DD
+            "filingDate": str | null,        # YYYY-MM-DD
+            "inventionTitle": str | null,
+            "cpcClassificationBag": list[str],   # e.g. "B01J  29/084"
+                                                 # (extra whitespace; collapsed)
+            "firstApplicantName": str | null,
+            ...
+          },
+          "assignmentBag": [
+            {"assigneeBag": [{"assigneeNameText": str}, ...]},
+            ...
+          ],
+          "grantDocumentMetaData": {"fileLocationURI": str},
+          ...
+        }, ...],
+        "requestIdentifier": str,
+      }
+
+    Patent numbers absent from the result set become fetch_status="not_found".
+    abstract + claims_text are NOT in this response — they come from the
+    grant XML fetched via grantDocumentMetaData.fileLocationURI by
+    _fetch_grant_xml / _parse_grant_xml. PatentsView v1 returned them inline;
+    ODP does not.
+    """
+    by_id: dict[str, tuple[PatentMetadata, dict[str, Any]]] = {}
+    for record in body.get("patentFileWrapperDataBag") or []:
+        meta = record.get("applicationMetaData") or {}
+        pn = meta.get("patentNumber")
+        if not pn:
+            continue
+        pn = str(pn)
+
+        cpc_raw = meta.get("cpcClassificationBag") or []
+        cpc_codes = [re.sub(r"\s+", " ", c).strip() for c in cpc_raw if c]
+
+        assignee = None
+        for ab in record.get("assignmentBag") or []:
+            for entry in ab.get("assigneeBag") or []:
+                name = entry.get("assigneeNameText")
+                if name:
+                    assignee = name
+                    break
+            if assignee:
+                break
+        if assignee is None:
+            assignee = meta.get("firstApplicantName")
+
+        by_id[pn] = (
+            PatentMetadata(
+                patent_number=pn,
+                filing_date=meta.get("filingDate"),
+                grant_date=meta.get("grantDate"),
+                abstract=None,
+                claims_text=None,
+                cpc_codes=cpc_codes,
+                assignee=assignee,
+                fetch_status="ok",
+            ),
+            record,
         )
-    out: list[PatentMetadata] = []
+
+    out: list[tuple[PatentMetadata, dict[str, Any]]] = []
     for pn in batch:
         if pn in by_id:
             out.append(by_id[pn])
         else:
-            out.append(
-                PatentMetadata(
-                    patent_number=pn,
-                    filing_date=None,
-                    grant_date=None,
-                    abstract=None,
-                    claims_text=None,
-                    cpc_codes=[],
-                    assignee=None,
-                    fetch_status="not_found",
-                )
-            )
+            out.append((_not_found_record(pn), {}))
     return out
+
+
+def _fetch_grant_xml(file_uri: str, api_key: str) -> str | None:
+    """Resolve and download the grant XML pointed to by an ODP fileLocationURI.
+
+    Two-step protocol:
+      1. GET <file_uri>  with X-API-Key, ``allow_redirects=False``
+         -> 302 with ``Location: <signed-url>`` (also echoed in body as
+            ``"Use redirect URL to download: <signed-url>. IMPORTANT..."``).
+            Older / mocked variants may return 200 with the same body and
+            no ``Location`` header — both shapes are handled.
+      2. GET <signed-url>  (no auth header)
+         -> 200, full grant XML
+    Returns the XML body, or None on any failure (caller treats this as
+    no-abstract/no-claims; metadata still counts as fetched).
+    """
+    try:
+        r = requests.get(
+            file_uri,
+            headers={"X-API-Key": api_key, "Accept": "application/json"},
+            timeout=30,
+            allow_redirects=False,
+        )
+        signed_url = r.headers.get("Location")
+        if not signed_url:
+            m = re.search(r"https://data\.uspto\.gov/[^\s\"]+", r.text)
+            if not m:
+                log.warning(
+                    "ODP file-location lookup returned %s with no signed URL",
+                    r.status_code,
+                )
+                return None
+            signed_url = m.group(0).rstrip(".")
+        rr = requests.get(signed_url, timeout=60)
+        if rr.status_code != 200:
+            log.warning("Grant XML download returned %s", rr.status_code)
+            return None
+        return rr.text
+    except requests.RequestException as exc:
+        log.warning("Grant XML fetch failed: %s", exc)
+        return None
+
+
+def _parse_grant_xml(xml: str) -> tuple[str | None, str | None]:
+    """Extract abstract + concatenated claims text from a USPTO grant XML.
+
+    Regex-based (USPTO grant XML has variable namespace/DTD shape; full XML
+    parsing trips on the entity declarations on older patents). Multiple
+    <claim ...>...</claim> blocks are concatenated newline-separated.
+    Inner tags are stripped; whitespace collapsed. Returns (None, None) if
+    the corresponding tag isn't present.
+    """
+    abstract: str | None = None
+    m = re.search(r"<abstract\b[^>]*>(.*?)</abstract>", xml, re.DOTALL)
+    if m:
+        abstract = re.sub(r"\s+", " ", re.sub(r"<[^>]+>", "", m.group(1))).strip() or None
+
+    claim_blocks = re.findall(r"<claim(?:\s[^>]*)?>(.*?)</claim>", xml, re.DOTALL)
+    claims_text: str | None = None
+    if claim_blocks:
+        cleaned = [
+            re.sub(r"\s+", " ", re.sub(r"<[^>]+>", "", b)).strip()
+            for b in claim_blocks
+        ]
+        cleaned = [c for c in cleaned if c]
+        if cleaned:
+            claims_text = "\n".join(cleaned)
+
+    return abstract, claims_text
+
+
+def _not_found_record(patent_number: str) -> PatentMetadata:
+    return PatentMetadata(
+        patent_number=patent_number,
+        filing_date=None,
+        grant_date=None,
+        abstract=None,
+        claims_text=None,
+        cpc_codes=[],
+        assignee=None,
+        fetch_status="not_found",
+    )
 
 
 def _error_record(patent_number: str) -> PatentMetadata:

--- a/src/aichemy/preprocessing/patents/fetch.py
+++ b/src/aichemy/preprocessing/patents/fetch.py
@@ -125,9 +125,7 @@ def _fetch_batch(
                 for rec, raw in pairs:
                     if rec.fetch_status != "ok":
                         continue
-                    file_uri = (raw.get("grantDocumentMetaData") or {}).get(
-                        "fileLocationURI"
-                    )
+                    file_uri = (raw.get("grantDocumentMetaData") or {}).get("fileLocationURI")
                     if not file_uri:
                         continue
                     try:
@@ -274,9 +272,7 @@ def _fetch_grant_xml(file_uri: str, api_key: str) -> str | None:
             allow_redirects=False,
         )
         if r.status_code in _GRANT_AUTH_ERROR_STATUSES:
-            raise GrantFetchError(
-                f"file-location lookup returned HTTP {r.status_code}"
-            )
+            raise GrantFetchError(f"file-location lookup returned HTTP {r.status_code}")
         signed_url = r.headers.get("Location")
         if not signed_url:
             m = re.search(r"https://data\.uspto\.gov/[^\s\"]+", r.text)
@@ -289,9 +285,7 @@ def _fetch_grant_xml(file_uri: str, api_key: str) -> str | None:
             signed_url = m.group(0).rstrip(".")
         rr = requests.get(signed_url, timeout=60)
         if rr.status_code in _GRANT_AUTH_ERROR_STATUSES:
-            raise GrantFetchError(
-                f"signed-URL download returned HTTP {rr.status_code}"
-            )
+            raise GrantFetchError(f"signed-URL download returned HTTP {rr.status_code}")
         if rr.status_code != 200:
             log.warning("Grant XML download returned %s", rr.status_code)
             return None
@@ -320,10 +314,7 @@ def _parse_grant_xml(xml: str) -> tuple[str | None, str | None]:
     claim_blocks = re.findall(r"<claim(?:\s[^>]*)?>(.*?)</claim>", xml, re.DOTALL)
     claims_text: str | None = None
     if claim_blocks:
-        cleaned = [
-            re.sub(r"\s+", " ", re.sub(r"<[^>]+>", "", b)).strip()
-            for b in claim_blocks
-        ]
+        cleaned = [re.sub(r"\s+", " ", re.sub(r"<[^>]+>", "", b)).strip() for b in claim_blocks]
         cleaned = [c for c in cleaned if c]
         if cleaned:
             claims_text = "\n".join(cleaned)

--- a/src/aichemy/preprocessing/patents/llm_classify.py
+++ b/src/aichemy/preprocessing/patents/llm_classify.py
@@ -111,9 +111,7 @@ def classify_patent_llm(
         messages=[{"role": "user", "content": user}],
     )
     if msg.stop_reason != "tool_use":
-        log.warning(
-            "Unexpected stop_reason=%s for patent=%s", msg.stop_reason, patent_number
-        )
+        log.warning("Unexpected stop_reason=%s for patent=%s", msg.stop_reason, patent_number)
         return None
     for block in msg.content:
         if getattr(block, "type", None) == "tool_use" and block.name == "report_classification":

--- a/src/aichemy/preprocessing/patents/llm_classify.py
+++ b/src/aichemy/preprocessing/patents/llm_classify.py
@@ -1,0 +1,120 @@
+"""LLM patent classifier using the Anthropic SDK with structured tool-use.
+
+The model is asked to judge two booleans (process_covered, composition_covered)
+plus a self-reported confidence and one-sentence rationale. We use Claude's
+tool-use schema to enforce structure rather than free-form JSON parsing.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+CLASSIFICATION_TOOL = {
+    "name": "report_classification",
+    "description": (
+        "Report whether the given patent's claims cover the synthesis route "
+        "(process) and/or any compound that participates in the reaction "
+        "(composition-of-matter)."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "process_covered": {
+                "type": "boolean",
+                "description": (
+                    "True iff the patent's INDEPENDENT claims cover this specific "
+                    "synthesis route (using these reactants, these conditions, this "
+                    "transformation). Mere disclosure in examples or background does NOT count."
+                ),
+            },
+            "composition_covered": {
+                "type": "boolean",
+                "description": (
+                    "True iff the patent's INDEPENDENT claims cover any participant "
+                    "compound (reactant, intermediate, or product) by composition-of-matter."
+                ),
+            },
+            "confidence": {
+                "type": "number",
+                "minimum": 0.0,
+                "maximum": 1.0,
+                "description": "Self-reported confidence in this classification.",
+            },
+            "rationale": {
+                "type": "string",
+                "description": (
+                    "One sentence citing the specific claim/passage that supports the answer."
+                ),
+            },
+        },
+        "required": ["process_covered", "composition_covered", "confidence", "rationale"],
+    },
+}
+
+
+SYSTEM_PROMPT = (
+    "You are a patent-claims analyst. Given a USPTO patent's title, abstract, and "
+    "independent claims, plus example reaction SMILES extracted from the patent, decide "
+    "whether the patent's CLAIMS (not its background or examples) cover the reaction's "
+    "synthesis route (process) and/or any participant compound by composition-of-matter. "
+    "Be strict: only report True when the claims clearly cover the item. When in doubt, "
+    "report False with a low confidence."
+)
+
+
+@dataclass
+class LLMClassificationResult:
+    process_covered: bool
+    composition_covered: bool
+    confidence: float
+    rationale: str
+
+
+def classify_patent_llm(
+    *,
+    client: Any,
+    patent_number: str,
+    title: str | None,
+    abstract: str | None,
+    claims_text: str | None,
+    reaction_smiles_examples: list[str],
+    model: str,
+) -> LLMClassificationResult | None:
+    """One LLM call, one classification. Returns None on unexpected stop_reason."""
+    examples = "\n".join(reaction_smiles_examples[:5]) or "(none)"
+    user = (
+        f"Patent number: {patent_number}\n\n"
+        f"Title: {title or '(none)'}\n\n"
+        f"Abstract:\n{abstract or '(none)'}\n\n"
+        f"Independent claims:\n{(claims_text or '(none)')[:8000]}\n\n"
+        f"Reaction SMILES extracted from this patent:\n{examples}\n\n"
+        "Use the report_classification tool."
+    )
+    msg = client.messages.create(
+        model=model,
+        max_tokens=512,
+        system=SYSTEM_PROMPT,
+        tools=[CLASSIFICATION_TOOL],
+        tool_choice={"type": "tool", "name": "report_classification"},
+        messages=[{"role": "user", "content": user}],
+    )
+    if msg.stop_reason != "tool_use":
+        log.warning(
+            "Unexpected stop_reason=%s for patent=%s", msg.stop_reason, patent_number
+        )
+        return None
+    for block in msg.content:
+        if getattr(block, "type", None) == "tool_use" and block.name == "report_classification":
+            data = block.input
+            return LLMClassificationResult(
+                process_covered=bool(data["process_covered"]),
+                composition_covered=bool(data["composition_covered"]),
+                confidence=float(data["confidence"]),
+                rationale=str(data["rationale"]),
+            )
+    return None

--- a/src/aichemy/preprocessing/patents/llm_classify.py
+++ b/src/aichemy/preprocessing/patents/llm_classify.py
@@ -8,8 +8,15 @@ tool-use schema to enforce structure rather than free-form JSON parsing.
 from __future__ import annotations
 
 import logging
+import time
 from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
+
+import polars as pl
+
+from aichemy.preprocessing.patents.cache import LLMCacheEntry, append_cache, load_cache
 
 log = logging.getLogger(__name__)
 
@@ -118,3 +125,151 @@ def classify_patent_llm(
                 rationale=str(data["rationale"]),
             )
     return None
+
+
+LLM_CLASSIFICATION_SCHEMA: dict[str, Any] = {
+    "patent_number": pl.Utf8,
+    "process_covered": pl.Boolean,
+    "composition_covered": pl.Boolean,
+    "confidence": pl.Float64,
+    "rationale": pl.Utf8,
+    "model": pl.Utf8,
+    "cache_hit": pl.Boolean,
+}
+
+
+def classify_ambiguous_patents(
+    *,
+    cpc: pl.DataFrame,
+    patents: pl.DataFrame,
+    reactions: pl.DataFrame,
+    cache_path: Path,
+    out_path: Path,
+    client: Any,
+    model: str,
+    max_retries: int = 3,
+    backoff_seconds: float = 1.0,
+) -> pl.DataFrame:
+    """Classify each unique patent flagged ambiguous + active.
+
+    Cache hits don't call the LLM. Misses call once per patent (no retries
+    on the LLM logic itself; transport-level retries on connection errors).
+    Failed calls fall back to (False, False, 0.0) and are NOT cached.
+    """
+    target_patents = (
+        cpc.filter(pl.col("cpc_ambiguous") & pl.col("patent_active"))
+        .select("patent_number")
+        .unique()["patent_number"]
+        .to_list()
+    )
+
+    cache = load_cache(cache_path)
+    rxn_smiles_by_patent = _smiles_index(cpc, reactions)
+    patent_meta = {r["patent_number"]: r for r in patents.iter_rows(named=True)}
+
+    rows: list[dict[str, Any]] = []
+    for pn in target_patents:
+        if pn in cache:
+            entry = cache[pn]
+            rows.append(_to_row(entry, cache_hit=True))
+            continue
+
+        meta = patent_meta.get(pn, {})
+        result = _call_with_retry(
+            client=client,
+            model=model,
+            patent_number=pn,
+            abstract=meta.get("abstract"),
+            claims_text=meta.get("claims_text"),
+            smiles_examples=rxn_smiles_by_patent.get(pn, []),
+            max_retries=max_retries,
+            backoff_seconds=backoff_seconds,
+        )
+        if result is None:
+            rows.append(
+                {
+                    "patent_number": pn,
+                    "process_covered": False,
+                    "composition_covered": False,
+                    "confidence": 0.0,
+                    "rationale": "LLM error — defaulted to no-license",
+                    "model": model,
+                    "cache_hit": False,
+                }
+            )
+            continue
+        entry = LLMCacheEntry(
+            patent_number=pn,
+            process_covered=result.process_covered,
+            composition_covered=result.composition_covered,
+            confidence=result.confidence,
+            rationale=result.rationale,
+            model=model,
+            ts=datetime.now(tz=timezone.utc).isoformat(),
+        )
+        append_cache(cache_path, entry)
+        rows.append(_to_row(entry, cache_hit=False))
+
+    df = pl.DataFrame(rows, schema=LLM_CLASSIFICATION_SCHEMA)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    df.write_parquet(out_path)
+    return df
+
+
+def _smiles_index(cpc: pl.DataFrame, reactions: pl.DataFrame) -> dict[str, list[str]]:
+    if "reaction_smiles" not in reactions.columns:
+        return {}
+    joined = cpc.select("rxn_id", "patent_number").join(
+        reactions.select("rxn_id", "reaction_smiles"), on="rxn_id", how="inner"
+    )
+    out: dict[str, list[str]] = {}
+    for r in joined.iter_rows(named=True):
+        out.setdefault(r["patent_number"], []).append(r["reaction_smiles"])
+    return out
+
+
+def _call_with_retry(
+    *,
+    client: Any,
+    model: str,
+    patent_number: str,
+    abstract: str | None,
+    claims_text: str | None,
+    smiles_examples: list[str],
+    max_retries: int,
+    backoff_seconds: float,
+) -> LLMClassificationResult | None:
+    for attempt in range(max_retries):
+        try:
+            return classify_patent_llm(
+                client=client,
+                patent_number=patent_number,
+                title=None,
+                abstract=abstract,
+                claims_text=claims_text,
+                reaction_smiles_examples=smiles_examples,
+                model=model,
+            )
+        except Exception as exc:
+            log.warning(
+                "LLM call failed (attempt %d/%d) for patent=%s: %s",
+                attempt + 1,
+                max_retries,
+                patent_number,
+                exc,
+            )
+            if attempt < max_retries - 1:
+                time.sleep(backoff_seconds * (2**attempt))
+    return None
+
+
+def _to_row(entry: LLMCacheEntry, *, cache_hit: bool) -> dict[str, Any]:
+    return {
+        "patent_number": entry.patent_number,
+        "process_covered": entry.process_covered,
+        "composition_covered": entry.composition_covered,
+        "confidence": entry.confidence,
+        "rationale": entry.rationale,
+        "model": entry.model,
+        "cache_hit": cache_hit,
+    }

--- a/src/aichemy/preprocessing/patents/llm_classify.py
+++ b/src/aichemy/preprocessing/patents/llm_classify.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -205,7 +205,7 @@ def classify_ambiguous_patents(
             confidence=result.confidence,
             rationale=result.rationale,
             model=model,
-            ts=datetime.now(tz=timezone.utc).isoformat(),
+            ts=datetime.now(tz=UTC).isoformat(),
         )
         append_cache(cache_path, entry)
         rows.append(_to_row(entry, cache_hit=False))

--- a/src/aichemy/solver/cli.py
+++ b/src/aichemy/solver/cli.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 
+import polars as pl
 import typer
 
 from aichemy.config import load_config
@@ -37,6 +39,21 @@ _BalanceFilterOpt = typer.Option(
         "Which boolean column gates reactions: 'rdkit_balanced' (default, "
         "strict atom-count) or 'balanced' (looser per-source claim)."
     ),
+)
+_RProcessOpt = typer.Option(
+    "0,0.02,0.04,0.06,0.08",
+    "--r-process",
+    help="Comma-separated decimal fractions for the process royalty axis.",
+)
+_RCompOpt = typer.Option(
+    "0,0.02,0.04,0.06,0.08",
+    "--r-comp",
+    help="Comma-separated decimal fractions for the composition royalty axis.",
+)
+_SweepOutOpt = typer.Option(
+    Path("data/processed/sensitivity"),
+    "--out",
+    help="Output directory.",
 )
 
 
@@ -77,4 +94,87 @@ def solve(
         f"activated={len(solution.activated_reactions)}  "
         f"sold={len(solution.sold_molecules)}  "
         f"→ {solver_cfg.output_path}"
+    )
+
+
+def _run_sweep(
+    reactions: pl.DataFrame,
+    molecules: pl.DataFrame,
+    *,
+    r_process_grid: list[float],
+    r_comp_grid: list[float],
+    out_dir: Path,
+    base_config: SolverConfig,
+) -> pl.DataFrame:
+    """Loop the (r_process, r_comp) grid; write per-cell solutions + summary parquet.
+
+    Per-cell output: ``out_dir/runs/r_process_<rp:.4f>_r_comp_<rc:.4f>/solution.json``.
+    Summary: ``out_dir/summary.parquet`` with one row per grid point and a
+    ``set_hash`` column for "decision invariance" plotting.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    rows: list[dict] = []
+    for rp in r_process_grid:
+        for rc in r_comp_grid:
+            cfg = base_config.model_copy(update={"r_process": rp, "r_comp": rc})
+            sol = build_and_solve(reactions, molecules, cfg)
+            cell_dir = out_dir / "runs" / f"r_process_{rp:.4f}_r_comp_{rc:.4f}"
+            cell_dir.mkdir(parents=True, exist_ok=True)
+            (cell_dir / "solution.json").write_text(json.dumps(sol.to_dict(), indent=2) + "\n")
+            sold_ids = sorted(s["mol_id"] for s in sol.sold_molecules)
+            set_hash = hashlib.sha256(",".join(sold_ids).encode()).hexdigest()[:16]
+            rows.append(
+                {
+                    "r_process": rp,
+                    "r_comp": rc,
+                    "objective_value": (
+                        float(sol.objective_value) if sol.status == "Optimal" else None
+                    ),
+                    "n_active_reactions": len(sol.activated_reactions),
+                    "n_sold_products": len(sol.sold_molecules),
+                    "set_hash": set_hash,
+                    "infeasible": sol.status == "Infeasible",
+                }
+            )
+    summary = pl.DataFrame(rows)
+    summary.write_parquet(out_dir / "summary.parquet")
+    return summary
+
+
+@solver_app.command("sweep")
+def sweep(
+    config: Path = _ConfigOpt,
+    override: list[Path] = _OverrideOpt,
+    r_process: str = _RProcessOpt,
+    r_comp: str = _RCompOpt,
+    out: Path = _SweepOutOpt,
+    backend: str = _BackendOpt,
+    verbose: bool = _VerboseOpt,
+    balance_filter: str = _BalanceFilterOpt,
+) -> None:
+    """Sweep the (r_process, r_comp) grid; write per-cell solutions + summary parquet."""
+    cfg = load_config(config, override)
+    base_cfg = SolverConfig(
+        backend=backend,  # type: ignore[arg-type]
+        verbose=verbose,
+        output_path=processed_path(cfg, "solution.json"),
+        balance_filter=balance_filter,  # type: ignore[arg-type]
+    )
+
+    reactions = read_reactions(processed_path(cfg, "reactions.parquet"))
+    molecules = read_molecules(processed_path(cfg, "molecules.parquet"))
+
+    rp_grid = [float(x) for x in r_process.split(",")]
+    rc_grid = [float(x) for x in r_comp.split(",")]
+    typer.echo(f"[solve sweep] {len(rp_grid)}x{len(rc_grid)} = {len(rp_grid) * len(rc_grid)} cells")
+    summary = _run_sweep(
+        reactions,
+        molecules,
+        r_process_grid=rp_grid,
+        r_comp_grid=rc_grid,
+        out_dir=out,
+        base_config=base_cfg,
+    )
+    typer.echo(
+        f"[solve sweep] complete; summary → {out / 'summary.parquet'} ({summary.height} rows)"
     )

--- a/src/aichemy/solver/config.py
+++ b/src/aichemy/solver/config.py
@@ -57,5 +57,13 @@ class SolverConfig(BaseModel):
     # Verbosity
     verbose: bool = False
 
+    # Royalty rate on process-covered reaction revenue (decimal fraction, [0, 1]).
+    # Default 0.0 preserves legacy behavior when license data is absent or
+    # the sweep CLI hasn't been invoked.
+    r_process: float = 0.0
+
+    # Royalty rate on composition-covered product revenue (decimal fraction, [0, 1]).
+    r_comp: float = 0.0
+
     # Where to write the JSON summary of the solved problem.
     output_path: Path = Field(default_factory=lambda: Path("data/processed/solution.json"))

--- a/src/aichemy/solver/model.py
+++ b/src/aichemy/solver/model.py
@@ -95,6 +95,19 @@ def build_and_solve(
     if reactions.height == 0:
         return Solution("No reactions after filtering", 0.0, [], [], [])
 
+    # Reaction-level composition_covered → molecule-level: any product of a
+    # composition-covered reaction is itself composition-covered for royalty.
+    # Defensive: only runs when the column is present (license data attached).
+    if "composition_covered" in reactions.columns:
+        comp_mol_ids: set[str] = set()
+        for row in reactions.iter_rows(named=True):
+            if row.get("composition_covered"):
+                for stoich in row["products"]:
+                    comp_mol_ids.add(stoich["mol_id"])
+        molecules = molecules.with_columns(
+            pl.col("mol_id").is_in(list(comp_mol_ids)).alias("composition_covered")
+        )
+
     # Universe of molecules is every mol_id referenced by a surviving reaction.
     referenced: set[str] = set()
     rxn_meta: list[dict[str, Any]] = []
@@ -113,8 +126,16 @@ def build_and_solve(
                 "yield_rate": yield_rate,
                 "reactants": reactants,
                 "products": products,
+                "process_covered": bool(row.get("process_covered") or False),
             }
         )
+
+    # Composition-covered molecule set (drives the composition royalty term).
+    composition_covered: set[str] = set()
+    if "composition_covered" in molecules.columns:
+        for r in molecules.iter_rows(named=True):
+            if r.get("composition_covered"):
+                composition_covered.add(r["mol_id"])
 
     # Price lookup: molecule mol_id → (buy_price, sell_price).
     price_lookup = _build_price_lookup(molecules, referenced, config)
@@ -146,12 +167,25 @@ def build_and_solve(
     }
     w = {mol_id: pulp.LpVariable(f"w_{_safe(mol_id)}", cat=pulp.LpBinary) for mol_id in referenced}
 
-    # Objective: sell revenue − buy cost
-    prob += (
-        pulp.lpSum(price_lookup[m][1] * q_sell[m] for m in referenced)
-        - pulp.lpSum(price_lookup[m][0] * q_buy[m] for m in referenced),
-        "total_profit",
+    # Objective: sell revenue − buy cost − process royalty − composition royalty.
+    # Royalty terms are zero whenever (a) license data isn't attached to the
+    # input reactions/molecules, or (b) config.r_process / config.r_comp are 0.
+    revenue = pulp.lpSum(price_lookup[m][1] * q_sell[m] for m in referenced)
+    cost = pulp.lpSum(price_lookup[m][0] * q_buy[m] for m in referenced)
+    process_royalty = pulp.lpSum(
+        config.r_process
+        * sum(price_lookup[mid][1] for (mid, _) in m["products"])
+        * m["yield_rate"]
+        * f[m["rxn_id"]]
+        for m in rxn_meta
+        if m["process_covered"]
     )
+    composition_royalty = pulp.lpSum(
+        config.r_comp * price_lookup[m][1] * q_sell[m]
+        for m in referenced
+        if m in composition_covered
+    )
+    prob += (revenue - cost - process_royalty - composition_royalty, "total_profit")
 
     # Mass balance: for each molecule, supply = consumption.
     for mol_id in referenced:

--- a/tests/fixtures/cpc_rules_test.yaml
+++ b/tests/fixtures/cpc_rules_test.yaml
@@ -1,0 +1,8 @@
+process_codes:
+  - "C07B"
+  - "C07C"
+composition_codes:
+  - "C07D"
+  - "C07K"
+ambiguous_codes:
+  - "A61K"

--- a/tests/fixtures/patents/sample_patentsview_response.json
+++ b/tests/fixtures/patents/sample_patentsview_response.json
@@ -1,25 +1,31 @@
 {
-  "patents": [
+  "count": 1,
+  "patentFileWrapperDataBag": [
     {
-      "patent_number": "7456123",
-      "patent_date": "2008-11-25",
-      "patent_abstract": "A method for the synthesis of substituted heterocyclic compounds...",
-      "claims": [{"text": "1. A process for preparing a compound of formula I..."}],
-      "cpcs": [
-        {"cpc_group_id": "C07D 401/12"},
-        {"cpc_group_id": "A61K 31/505"}
+      "applicationNumberText": "11106297",
+      "applicationMetaData": {
+        "patentNumber": "7456123",
+        "grantDate": "2008-11-25",
+        "filingDate": "2005-04-14",
+        "inventionTitle": "FCC CATALYST",
+        "cpcClassificationBag": [
+          "B01J  29/084",
+          "B01J  35/647",
+          "C10G  11/02"
+        ],
+        "firstApplicantName": "ExxonMobil Research and Engineering Company"
+      },
+      "assignmentBag": [
+        {
+          "assigneeBag": [
+            {"assigneeNameText": "EXXONMOBIL RESEARCH & ENGINEERING CO."}
+          ]
+        }
       ],
-      "assignees": [{"assignee_organization": "Acme Pharmaceuticals"}],
-      "application": {"filing_date": "2005-03-14"}
-    },
-    {
-      "patent_number": "9999999",
-      "patent_date": null,
-      "patent_abstract": null,
-      "claims": [],
-      "cpcs": [],
-      "assignees": [],
-      "application": {"filing_date": "1985-01-01"}
+      "grantDocumentMetaData": {
+        "fileLocationURI": "https://api.uspto.gov/api/v1/datasets/products/files/PTGRXML-SPLT/2008/ipg081125/11106297_07456123.xml"
+      }
     }
-  ]
+  ],
+  "requestIdentifier": "fixture-7456123"
 }

--- a/tests/fixtures/patents/sample_patentsview_response.json
+++ b/tests/fixtures/patents/sample_patentsview_response.json
@@ -1,0 +1,25 @@
+{
+  "patents": [
+    {
+      "patent_number": "7456123",
+      "patent_date": "2008-11-25",
+      "patent_abstract": "A method for the synthesis of substituted heterocyclic compounds...",
+      "claims": [{"text": "1. A process for preparing a compound of formula I..."}],
+      "cpcs": [
+        {"cpc_group_id": "C07D 401/12"},
+        {"cpc_group_id": "A61K 31/505"}
+      ],
+      "assignees": [{"assignee_organization": "Acme Pharmaceuticals"}],
+      "application": {"filing_date": "2005-03-14"}
+    },
+    {
+      "patent_number": "9999999",
+      "patent_date": null,
+      "patent_abstract": null,
+      "claims": [],
+      "cpcs": [],
+      "assignees": [],
+      "application": {"filing_date": "1985-01-01"}
+    }
+  ]
+}

--- a/tests/integration/test_dvc_repro_licenses.py
+++ b/tests/integration/test_dvc_repro_licenses.py
@@ -1,8 +1,8 @@
 """End-to-end integration test for the licensing stages.
 
-Runs the four new pipeline stages on a tiny synthetic fixture, with
-PatentsView calls stubbed via ``responses`` and Anthropic calls stubbed
-via a ``MagicMock`` client. Verifies the data flows through to the
+Runs the four new pipeline stages on a tiny synthetic fixture, with USPTO
+ODP calls stubbed via ``responses`` and Anthropic calls stubbed via a
+``MagicMock`` client. Verifies the data flows through to the
 ``augment_licenses`` output with correct columns for both USPTO and
 MetaNetX rows (the latter exercises the left-join + ``fill_null(False)``
 fallback path).
@@ -18,7 +18,20 @@ import polars as pl
 import pytest
 import responses
 
-PATENTSVIEW = "https://search.patentsview.org/api/v1/patent"
+ODP_SEARCH = "https://api.uspto.gov/api/v1/patent/applications/search"
+ODP_FILE_URI = (
+    "https://api.uspto.gov/api/v1/datasets/products/files/PTGRXML-SPLT/"
+    "2015/ipg150915/12345678_07456123.xml"
+)
+ODP_SIGNED_URL = "https://data.uspto.gov/files/integration-sample.xml"
+SAMPLE_GRANT_XML = """<?xml version="1.0"?>
+<us-patent-grant>
+  <abstract id="abstract"><p>A medicinal preparation.</p></abstract>
+  <claims>
+    <claim id="CLM-00001"><claim-text>1. A composition comprising the active.</claim-text></claim>
+  </claims>
+</us-patent-grant>
+"""
 
 
 @pytest.fixture
@@ -54,23 +67,38 @@ def test_full_license_flow_with_stubbed_apis(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     responses.add(
-        responses.POST,
-        PATENTSVIEW,
+        responses.GET,
+        ODP_SEARCH,
         json={
-            "patents": [
+            "count": 1,
+            "patentFileWrapperDataBag": [
                 {
-                    "patent_number": "7456123",
-                    "patent_date": "2008-11-25",
-                    "patent_abstract": "A medicinal preparation for…",
-                    "claims": [{"text": "1. A composition comprising…"}],
-                    "cpcs": [{"cpc_group_id": "A61K 31/505"}],
-                    "assignees": [{"assignee_organization": "Acme"}],
-                    "application": {"filing_date": "2015-03-14"},
+                    "applicationNumberText": "12345678",
+                    "applicationMetaData": {
+                        "patentNumber": "7456123",
+                        "grantDate": "2015-09-15",
+                        "filingDate": "2015-03-14",
+                        "inventionTitle": "MEDICINAL PREPARATION",
+                        "cpcClassificationBag": ["A61K 31/505"],
+                    },
+                    "assignmentBag": [
+                        {"assigneeBag": [{"assigneeNameText": "Acme"}]}
+                    ],
+                    "grantDocumentMetaData": {"fileLocationURI": ODP_FILE_URI},
                 }
-            ]
+            ],
+            "requestIdentifier": "integration-test",
         },
         status=200,
     )
+    responses.add(
+        responses.GET,
+        ODP_FILE_URI,
+        body=f'"Use redirect URL to download: {ODP_SIGNED_URL}. IMPORTANT..."',
+        status=200,
+    )
+    responses.add(responses.GET, ODP_SIGNED_URL, body=SAMPLE_GRANT_XML, status=200)
+    monkeypatch.setenv("USPTO_ODP_API_KEY", "fake-key-for-test")
 
     fake_block = MagicMock()
     fake_block.type = "tool_use"
@@ -108,7 +136,7 @@ def test_full_license_flow_with_stubbed_apis(
     reactions = pl.read_parquet(fake_reactions_full)
 
     # 1. fetch_patent_metadata
-    items = fetch_patents(["7456123"], endpoint=PATENTSVIEW, max_retries=1)
+    items = fetch_patents(["7456123"], endpoint=ODP_SEARCH, max_retries=1)
     patents_path = tmp_path / "patent_metadata.parquet"
     write_metadata_parquet(items, patents_path)
 

--- a/tests/integration/test_dvc_repro_licenses.py
+++ b/tests/integration/test_dvc_repro_licenses.py
@@ -81,9 +81,7 @@ def test_full_license_flow_with_stubbed_apis(
                         "inventionTitle": "MEDICINAL PREPARATION",
                         "cpcClassificationBag": ["A61K 31/505"],
                     },
-                    "assignmentBag": [
-                        {"assigneeBag": [{"assigneeNameText": "Acme"}]}
-                    ],
+                    "assignmentBag": [{"assigneeBag": [{"assigneeNameText": "Acme"}]}],
                     "grantDocumentMetaData": {"fileLocationURI": ODP_FILE_URI},
                 }
             ],

--- a/tests/integration/test_dvc_repro_licenses.py
+++ b/tests/integration/test_dvc_repro_licenses.py
@@ -1,0 +1,156 @@
+"""End-to-end integration test for the licensing stages.
+
+Runs the four new pipeline stages on a tiny synthetic fixture, with
+PatentsView calls stubbed via ``responses`` and Anthropic calls stubbed
+via a ``MagicMock`` client. Verifies the data flows through to the
+``augment_licenses`` output with correct columns for both USPTO and
+MetaNetX rows (the latter exercises the left-join + ``fill_null(False)``
+fallback path).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import polars as pl
+import pytest
+import responses
+
+PATENTSVIEW = "https://search.patentsview.org/api/v1/patent"
+
+
+@pytest.fixture
+def fake_reactions_full(tmp_path: Path) -> Path:
+    df = pl.DataFrame(
+        {
+            "rxn_id": ["USPTO:7456123:0", "MNXR1"],
+            "reaction_smiles": ["A.B>>C", "X>>Y"],
+            "reactants": [
+                [{"mol_id": "A", "coefficient": 1.0}, {"mol_id": "B", "coefficient": 1.0}],
+                [{"mol_id": "X", "coefficient": 1.0}],
+            ],
+            "products": [
+                [{"mol_id": "C", "coefficient": 1.0}],
+                [{"mol_id": "Y", "coefficient": 1.0}],
+            ],
+            "type": ["chemical", "enzymatic"],
+            "yield_rate": [0.85, 0.95],
+            "delta_g": [None, None],
+            "balanced": [True, True],
+            "source": ["uspto", "metanetx"],
+        }
+    )
+    out = tmp_path / "reactions_full.parquet"
+    df.write_parquet(out)
+    return out
+
+
+@responses.activate
+def test_full_license_flow_with_stubbed_apis(
+    tmp_path: Path,
+    fake_reactions_full: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    responses.add(
+        responses.POST,
+        PATENTSVIEW,
+        json={
+            "patents": [
+                {
+                    "patent_number": "7456123",
+                    "patent_date": "2008-11-25",
+                    "patent_abstract": "A medicinal preparation for…",
+                    "claims": [{"text": "1. A composition comprising…"}],
+                    "cpcs": [{"cpc_group_id": "A61K 31/505"}],
+                    "assignees": [{"assignee_organization": "Acme"}],
+                    "application": {"filing_date": "2015-03-14"},
+                }
+            ]
+        },
+        status=200,
+    )
+
+    fake_block = MagicMock()
+    fake_block.type = "tool_use"
+    fake_block.name = "report_classification"
+    fake_block.input = {
+        "process_covered": False,
+        "composition_covered": True,
+        "confidence": 0.9,
+        "rationale": "Independent claim 1 is composition-of-matter.",
+    }
+    fake_msg = MagicMock()
+    fake_msg.stop_reason = "tool_use"
+    fake_msg.content = [fake_block]
+    fake_client = MagicMock()
+    fake_client.messages.create.return_value = fake_msg
+
+    import anthropic
+
+    monkeypatch.setattr(anthropic, "Anthropic", lambda *a, **kw: fake_client)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "fake-key-for-test")
+
+    from aichemy.preprocessing.augment.licenses import augment_licenses
+    from aichemy.preprocessing.patents.cpc import (
+        classify_dataframe,
+        load_cpc_rules,
+    )
+    from aichemy.preprocessing.patents.fetch import (
+        fetch_patents,
+        write_metadata_parquet,
+    )
+    from aichemy.preprocessing.patents.llm_classify import (
+        classify_ambiguous_patents,
+    )
+
+    reactions = pl.read_parquet(fake_reactions_full)
+
+    # 1. fetch_patent_metadata
+    items = fetch_patents(["7456123"], endpoint=PATENTSVIEW, max_retries=1)
+    patents_path = tmp_path / "patent_metadata.parquet"
+    write_metadata_parquet(items, patents_path)
+
+    # 2. classify_licenses_cpc
+    rules = load_cpc_rules(Path("configs/cpc_rules.yaml"))
+    cpc_df = classify_dataframe(
+        reactions,
+        pl.read_parquet(patents_path),
+        rules=rules,
+        today=date(2026, 4, 25),
+    )
+    cpc_path = tmp_path / "cpc.parquet"
+    cpc_df.write_parquet(cpc_path)
+
+    # 3. classify_licenses_llm
+    llm_df = classify_ambiguous_patents(
+        cpc=cpc_df,
+        patents=pl.read_parquet(patents_path),
+        reactions=reactions,
+        cache_path=tmp_path / "cache.jsonl",
+        out_path=tmp_path / "llm.parquet",
+        client=fake_client,
+        model="claude-haiku-4-5",
+        max_retries=1,
+    )
+
+    # 4. augment_licenses
+    out = augment_licenses(reactions, cpc_df, llm_df)
+
+    # Schema: all three license columns present.
+    assert {"patent_active", "process_covered", "composition_covered"} <= set(out.columns)
+
+    by_rxn = {r["rxn_id"]: r for r in out.iter_rows(named=True)}
+
+    # USPTO row: A61K is in ambiguous_codes → LLM verdict (False, True) wins.
+    # filing_date 2015-03-14 + 20y = 2035-03-14 > today=2026-04-25 → active.
+    assert by_rxn["USPTO:7456123:0"]["patent_active"] is True
+    assert by_rxn["USPTO:7456123:0"]["process_covered"] is False
+    assert by_rxn["USPTO:7456123:0"]["composition_covered"] is True
+
+    # MetaNetX row: source=="metanetx" is excluded from cpc_df by
+    # classify_dataframe, then left-joined back as null and fill_null(False).
+    assert by_rxn["MNXR1"]["patent_active"] is False
+    assert by_rxn["MNXR1"]["process_covered"] is False
+    assert by_rxn["MNXR1"]["composition_covered"] is False

--- a/tests/unit/test_augment_licenses.py
+++ b/tests/unit/test_augment_licenses.py
@@ -1,0 +1,112 @@
+"""Resolution rule for the augment_licenses merge step (Task 14)."""
+
+from __future__ import annotations
+
+import polars as pl
+
+from aichemy.preprocessing.augment.licenses import augment_licenses
+
+
+def _reactions(rxns):
+    return pl.DataFrame(
+        {
+            "rxn_id": [r[0] for r in rxns],
+            "source": [r[1] for r in rxns],
+            "balanced": [True] * len(rxns),
+        }
+    )
+
+
+def _empty_cpc():
+    return pl.DataFrame(
+        schema={
+            "rxn_id": pl.Utf8,
+            "patent_number": pl.Utf8,
+            "patent_active": pl.Boolean,
+            "cpc_ambiguous": pl.Boolean,
+            "process_covered_cpc": pl.Boolean,
+            "composition_covered_cpc": pl.Boolean,
+        }
+    )
+
+
+def _empty_llm():
+    return pl.DataFrame(
+        schema={
+            "patent_number": pl.Utf8,
+            "process_covered": pl.Boolean,
+            "composition_covered": pl.Boolean,
+        }
+    )
+
+
+def test_metanetx_rows_get_all_false():
+    reactions = _reactions([("MNXR1", "metanetx")])
+    out = augment_licenses(reactions, _empty_cpc(), _empty_llm())
+    row = out.row(0, named=True)
+    assert row["patent_active"] is False
+    assert row["process_covered"] is False
+    assert row["composition_covered"] is False
+
+
+def test_uspto_unambiguous_uses_cpc():
+    reactions = _reactions([("USPTO:A:0", "uspto")])
+    cpc = pl.DataFrame(
+        {
+            "rxn_id": ["USPTO:A:0"],
+            "patent_number": ["A"],
+            "patent_active": [True],
+            "cpc_ambiguous": [False],
+            "process_covered_cpc": [True],
+            "composition_covered_cpc": [False],
+        }
+    )
+    out = augment_licenses(reactions, cpc, _empty_llm())
+    row = out.row(0, named=True)
+    assert row["patent_active"] is True
+    assert row["process_covered"] is True
+    assert row["composition_covered"] is False
+
+
+def test_uspto_ambiguous_uses_llm_when_present():
+    reactions = _reactions([("USPTO:B:0", "uspto")])
+    cpc = pl.DataFrame(
+        {
+            "rxn_id": ["USPTO:B:0"],
+            "patent_number": ["B"],
+            "patent_active": [True],
+            "cpc_ambiguous": [True],
+            "process_covered_cpc": [False],
+            "composition_covered_cpc": [False],
+        }
+    )
+    llm = pl.DataFrame(
+        {
+            "patent_number": ["B"],
+            "process_covered": [False],
+            "composition_covered": [True],
+        }
+    )
+    out = augment_licenses(reactions, cpc, llm)
+    row = out.row(0, named=True)
+    assert row["process_covered"] is False
+    assert row["composition_covered"] is True
+
+
+def test_uspto_ambiguous_falls_back_to_false_when_llm_missing():
+    reactions = _reactions([("USPTO:C:0", "uspto")])
+    cpc = pl.DataFrame(
+        {
+            "rxn_id": ["USPTO:C:0"],
+            "patent_number": ["C"],
+            "patent_active": [True],
+            "cpc_ambiguous": [True],
+            "process_covered_cpc": [False],
+            "composition_covered_cpc": [False],
+        }
+    )
+    out = augment_licenses(reactions, cpc, _empty_llm())
+    row = out.row(0, named=True)
+    assert row["patent_active"] is True
+    assert row["process_covered"] is False
+    assert row["composition_covered"] is False

--- a/tests/unit/test_config_licenses.py
+++ b/tests/unit/test_config_licenses.py
@@ -7,7 +7,7 @@ from aichemy.config import LicensesConfig, load_config
 
 def test_licenses_config_defaults():
     cfg = LicensesConfig()
-    assert cfg.patentsview_endpoint == "https://search.patentsview.org/api/v1/patent"
+    assert cfg.patentsview_endpoint == "https://api.uspto.gov/api/v1/patent/applications/search"
     assert cfg.llm_model == "claude-haiku-4-5"
     assert cfg.cpc_rules_path == Path("configs/cpc_rules.yaml")
     assert cfg.cache_path == Path("data/interim/licenses/llm_cache.jsonl")

--- a/tests/unit/test_patents_cpc.py
+++ b/tests/unit/test_patents_cpc.py
@@ -1,0 +1,136 @@
+from datetime import date
+from pathlib import Path
+
+import polars as pl
+
+from aichemy.preprocessing.patents.cpc import (
+    CPC_CLASSIFICATION_SCHEMA,
+    CPCRules,
+    classify_dataframe,
+    classify_patent,
+    load_cpc_rules,
+)
+
+RULES_PATH = Path(__file__).parent.parent / "fixtures" / "cpc_rules_test.yaml"
+
+
+def _rules() -> CPCRules:
+    return load_cpc_rules(RULES_PATH)
+
+
+def test_inactive_patent_short_circuits():
+    today = date(2026, 4, 25)
+    out = classify_patent(
+        cpc_codes=["C07D 401/12"],
+        filing_date_str="1985-01-01",
+        today=today,
+        rules=_rules(),
+    )
+    assert out.patent_active is False
+    assert out.process_covered_cpc is False
+    assert out.composition_covered_cpc is False
+    assert out.cpc_ambiguous is False
+
+
+def test_active_process_only():
+    today = date(2026, 4, 25)
+    out = classify_patent(
+        cpc_codes=["C07C 1/00"],
+        filing_date_str="2015-06-01",
+        today=today,
+        rules=_rules(),
+    )
+    assert out.patent_active is True
+    assert out.cpc_process_hit is True
+    assert out.cpc_composition_hit is False
+    assert out.cpc_ambiguous is False
+    assert out.process_covered_cpc is True
+    assert out.composition_covered_cpc is False
+
+
+def test_active_composition_only():
+    today = date(2026, 4, 25)
+    out = classify_patent(
+        cpc_codes=["C07D 401/12"],
+        filing_date_str="2015-06-01",
+        today=today,
+        rules=_rules(),
+    )
+    assert out.cpc_process_hit is False
+    assert out.cpc_composition_hit is True
+    assert out.cpc_ambiguous is False
+    assert out.process_covered_cpc is False
+    assert out.composition_covered_cpc is True
+
+
+def test_active_both_hit_is_ambiguous():
+    today = date(2026, 4, 25)
+    out = classify_patent(
+        cpc_codes=["C07C 1/00", "C07D 401/12"],
+        filing_date_str="2015-06-01",
+        today=today,
+        rules=_rules(),
+    )
+    assert out.cpc_ambiguous is True
+    assert out.process_covered_cpc is False
+    assert out.composition_covered_cpc is False
+
+
+def test_active_a61k_is_ambiguous():
+    today = date(2026, 4, 25)
+    out = classify_patent(
+        cpc_codes=["A61K 31/505"],
+        filing_date_str="2015-06-01",
+        today=today,
+        rules=_rules(),
+    )
+    assert out.cpc_ambiguous is True
+
+
+def test_active_no_chemistry_codes_is_ambiguous():
+    today = date(2026, 4, 25)
+    out = classify_patent(
+        cpc_codes=["G06F 17/00"],
+        filing_date_str="2015-06-01",
+        today=today,
+        rules=_rules(),
+    )
+    assert out.cpc_ambiguous is True
+
+
+def test_missing_filing_date_treated_inactive():
+    today = date(2026, 4, 25)
+    out = classify_patent(
+        cpc_codes=["C07D"],
+        filing_date_str=None,
+        today=today,
+        rules=_rules(),
+    )
+    assert out.patent_active is False
+
+
+def test_classify_dataframe_joins_reactions_and_patents():
+    today = date(2026, 4, 25)
+    rules = _rules()
+    reactions = pl.DataFrame(
+        {
+            "rxn_id": ["USPTO:7456123:0", "USPTO:1985111:0", "MNXR1"],
+            "source": ["uspto", "uspto", "metanetx"],
+        }
+    )
+    patents = pl.DataFrame(
+        {
+            "patent_number": ["7456123", "1985111"],
+            "filing_date": ["2015-06-01", "1985-01-01"],
+            "cpc_codes": [["C07D 401/12"], ["C07D 401/12"]],
+        }
+    )
+    out = classify_dataframe(reactions, patents, rules=rules, today=today)
+    assert out.height == 2
+    by_rxn = {r["rxn_id"]: r for r in out.iter_rows(named=True)}
+    assert by_rxn["USPTO:7456123:0"]["patent_active"] is True
+    assert by_rxn["USPTO:7456123:0"]["composition_covered_cpc"] is True
+    assert by_rxn["USPTO:1985111:0"]["patent_active"] is False
+    for col, dtype in CPC_CLASSIFICATION_SCHEMA.items():
+        assert col in out.columns
+        assert out.schema[col] == dtype

--- a/tests/unit/test_patents_fetch.py
+++ b/tests/unit/test_patents_fetch.py
@@ -24,8 +24,12 @@ SAMPLE_GRANT_XML = """<?xml version="1.0"?>
     <p>A method for the synthesis of substituted heterocyclic compounds.</p>
   </abstract>
   <claims>
-    <claim id="CLM-00001"><claim-text>1. A process for preparing a compound of formula I.</claim-text></claim>
-    <claim id="CLM-00002"><claim-text>2. The process of claim 1.</claim-text></claim>
+    <claim id="CLM-00001">
+      <claim-text>1. A process for preparing a compound of formula I.</claim-text>
+    </claim>
+    <claim id="CLM-00002">
+      <claim-text>2. The process of claim 1.</claim-text>
+    </claim>
   </claims>
 </us-patent-grant>
 """

--- a/tests/unit/test_patents_fetch.py
+++ b/tests/unit/test_patents_fetch.py
@@ -1,0 +1,78 @@
+import json
+from pathlib import Path
+
+import polars as pl
+import responses
+
+from aichemy.preprocessing.patents.fetch import (
+    PatentMetadata,
+    fetch_patents,
+    write_metadata_parquet,
+)
+
+FIXTURE = Path(__file__).parent.parent / "fixtures" / "patents" / "sample_patentsview_response.json"
+ENDPOINT = "https://search.patentsview.org/api/v1/patent"
+
+
+@responses.activate
+def test_fetch_patents_returns_metadata_objects():
+    responses.add(
+        responses.POST,
+        ENDPOINT,
+        json=json.loads(FIXTURE.read_text()),
+        status=200,
+    )
+    out = fetch_patents(["7456123", "9999999"], endpoint=ENDPOINT, max_retries=1)
+    assert len(out) == 2
+    by_id = {p.patent_number: p for p in out}
+    assert by_id["7456123"].filing_date == "2005-03-14"
+    assert by_id["7456123"].abstract.startswith("A method")
+    assert "C07D 401/12" in by_id["7456123"].cpc_codes
+    assert by_id["7456123"].claims_text.startswith("1. A process")
+    assert by_id["7456123"].fetch_status == "ok"
+    assert by_id["9999999"].abstract is None
+    assert by_id["9999999"].fetch_status == "ok"
+
+
+@responses.activate
+def test_fetch_patents_records_error_status_after_retry_exhaustion():
+    responses.add(responses.POST, ENDPOINT, status=500)
+    out = fetch_patents(["7456123"], endpoint=ENDPOINT, max_retries=2)
+    assert len(out) == 1
+    assert out[0].fetch_status == "error"
+
+
+def test_patent_metadata_dataclass_shape():
+    p = PatentMetadata(
+        patent_number="123",
+        filing_date="2010-01-01",
+        grant_date=None,
+        abstract=None,
+        claims_text=None,
+        cpc_codes=[],
+        assignee=None,
+        fetch_status="ok",
+    )
+    assert p.patent_number == "123"
+
+
+def test_write_metadata_parquet(tmp_path: Path):
+    items = [
+        PatentMetadata(
+            patent_number="123",
+            filing_date="2010-01-01",
+            grant_date="2012-06-15",
+            abstract="abc",
+            claims_text="1. claim",
+            cpc_codes=["C07D"],
+            assignee="X Inc",
+            fetch_status="ok",
+        ),
+    ]
+    out = tmp_path / "patents.parquet"
+    write_metadata_parquet(items, out)
+    df = pl.read_parquet(out)
+    assert df.height == 1
+    assert df["patent_number"][0] == "123"
+    assert df["cpc_codes"][0].to_list() == ["C07D"]
+    assert df["fetch_status"][0] == "ok"

--- a/tests/unit/test_patents_fetch.py
+++ b/tests/unit/test_patents_fetch.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 import polars as pl
+import pytest
 import responses
 
 from aichemy.preprocessing.patents.fetch import (
@@ -11,32 +12,66 @@ from aichemy.preprocessing.patents.fetch import (
 )
 
 FIXTURE = Path(__file__).parent.parent / "fixtures" / "patents" / "sample_patentsview_response.json"
-ENDPOINT = "https://search.patentsview.org/api/v1/patent"
+ENDPOINT = "https://api.uspto.gov/api/v1/patent/applications/search"
+GRANT_FILE_URI = (
+    "https://api.uspto.gov/api/v1/datasets/products/files/PTGRXML-SPLT/"
+    "2008/ipg081125/11106297_07456123.xml"
+)
+SIGNED_URL = "https://data.uspto.gov/files/sample.xml"
+SAMPLE_GRANT_XML = """<?xml version="1.0"?>
+<us-patent-grant>
+  <abstract id="abstract">
+    <p>A method for the synthesis of substituted heterocyclic compounds.</p>
+  </abstract>
+  <claims>
+    <claim id="CLM-00001"><claim-text>1. A process for preparing a compound of formula I.</claim-text></claim>
+    <claim id="CLM-00002"><claim-text>2. The process of claim 1.</claim-text></claim>
+  </claims>
+</us-patent-grant>
+"""
+
+
+@pytest.fixture(autouse=True)
+def _set_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("USPTO_ODP_API_KEY", "fake-key-for-test")
 
 
 @responses.activate
 def test_fetch_patents_returns_metadata_objects():
     responses.add(
-        responses.POST,
+        responses.GET,
         ENDPOINT,
         json=json.loads(FIXTURE.read_text()),
         status=200,
     )
+    responses.add(
+        responses.GET,
+        GRANT_FILE_URI,
+        body=f'"Use redirect URL to download: {SIGNED_URL}. IMPORTANT..."',
+        status=200,
+    )
+    responses.add(responses.GET, SIGNED_URL, body=SAMPLE_GRANT_XML, status=200)
+
     out = fetch_patents(["7456123", "9999999"], endpoint=ENDPOINT, max_retries=1)
     assert len(out) == 2
     by_id = {p.patent_number: p for p in out}
-    assert by_id["7456123"].filing_date == "2005-03-14"
-    assert by_id["7456123"].abstract.startswith("A method")
-    assert "C07D 401/12" in by_id["7456123"].cpc_codes
-    assert by_id["7456123"].claims_text.startswith("1. A process")
+
     assert by_id["7456123"].fetch_status == "ok"
+    assert by_id["7456123"].filing_date == "2005-04-14"
+    assert by_id["7456123"].grant_date == "2008-11-25"
+    assert by_id["7456123"].assignee == "EXXONMOBIL RESEARCH & ENGINEERING CO."
+    assert "B01J 29/084" in by_id["7456123"].cpc_codes
+    assert by_id["7456123"].abstract.startswith("A method")
+    assert by_id["7456123"].claims_text.startswith("1.")
+
+    assert by_id["9999999"].fetch_status == "not_found"
     assert by_id["9999999"].abstract is None
-    assert by_id["9999999"].fetch_status == "ok"
+    assert by_id["9999999"].cpc_codes == []
 
 
 @responses.activate
 def test_fetch_patents_records_error_status_after_retry_exhaustion():
-    responses.add(responses.POST, ENDPOINT, status=500)
+    responses.add(responses.GET, ENDPOINT, status=500)
     out = fetch_patents(["7456123"], endpoint=ENDPOINT, max_retries=2)
     assert len(out) == 1
     assert out[0].fetch_status == "error"

--- a/tests/unit/test_patents_fetch.py
+++ b/tests/unit/test_patents_fetch.py
@@ -81,6 +81,28 @@ def test_fetch_patents_records_error_status_after_retry_exhaustion():
     assert out[0].fetch_status == "error"
 
 
+@responses.activate
+def test_fetch_grant_xml_auth_error_sets_error_status():
+    """401 on the file-location lookup propagates to fetch_status='error'."""
+    responses.add(
+        responses.GET,
+        ENDPOINT,
+        json=json.loads(FIXTURE.read_text()),
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        GRANT_FILE_URI,
+        status=401,
+    )
+
+    out = fetch_patents(["7456123"], endpoint=ENDPOINT, max_retries=1)
+    assert len(out) >= 1
+    by_id = {p.patent_number: p for p in out}
+    assert by_id["7456123"].fetch_status == "error"
+    assert by_id["7456123"].abstract is None
+
+
 def test_patent_metadata_dataclass_shape():
     p = PatentMetadata(
         patent_number="123",

--- a/tests/unit/test_patents_llm_cache.py
+++ b/tests/unit/test_patents_llm_cache.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+from aichemy.preprocessing.patents.cache import (
+    LLMCacheEntry,
+    append_cache,
+    load_cache,
+)
+
+
+def test_load_cache_missing_file_returns_empty(tmp_path: Path):
+    cache_path = tmp_path / "cache.jsonl"
+    assert load_cache(cache_path) == {}
+
+
+def test_append_then_load_roundtrip(tmp_path: Path):
+    cache_path = tmp_path / "cache.jsonl"
+    e = LLMCacheEntry(
+        patent_number="123",
+        process_covered=True,
+        composition_covered=False,
+        confidence=0.9,
+        rationale="claim 1 covers a method",
+        model="claude-haiku-4-5",
+        ts="2026-04-25T00:00:00Z",
+    )
+    append_cache(cache_path, e)
+    loaded = load_cache(cache_path)
+    assert "123" in loaded
+    assert loaded["123"].process_covered is True
+
+
+def test_later_entry_wins_for_duplicate_keys(tmp_path: Path):
+    cache_path = tmp_path / "cache.jsonl"
+    e1 = LLMCacheEntry(
+        patent_number="X",
+        process_covered=False,
+        composition_covered=False,
+        confidence=0.5,
+        rationale="r1",
+        model="m1",
+        ts="2026-01-01T00:00:00Z",
+    )
+    e2 = LLMCacheEntry(
+        patent_number="X",
+        process_covered=True,
+        composition_covered=True,
+        confidence=0.9,
+        rationale="r2",
+        model="m1",
+        ts="2026-04-01T00:00:00Z",
+    )
+    append_cache(cache_path, e1)
+    append_cache(cache_path, e2)
+    loaded = load_cache(cache_path)
+    assert loaded["X"].process_covered is True
+    assert loaded["X"].rationale == "r2"

--- a/tests/unit/test_patents_llm_classify.py
+++ b/tests/unit/test_patents_llm_classify.py
@@ -1,7 +1,14 @@
+from datetime import datetime, timezone
+from pathlib import Path
 from unittest.mock import MagicMock
 
+import polars as pl
+
+from aichemy.preprocessing.patents.cache import LLMCacheEntry, append_cache
 from aichemy.preprocessing.patents.llm_classify import (
+    LLM_CLASSIFICATION_SCHEMA,
     LLMClassificationResult,
+    classify_ambiguous_patents,
     classify_patent_llm,
 )
 
@@ -57,3 +64,117 @@ def test_classify_patent_llm_returns_none_on_unexpected_stop_reason():
         model="claude-haiku-4-5",
     )
     assert out is None
+
+
+def test_classify_ambiguous_patents_uses_cache_when_present(tmp_path: Path):
+    cache_path = tmp_path / "cache.jsonl"
+    append_cache(
+        cache_path,
+        LLMCacheEntry(
+            patent_number="A",
+            process_covered=True,
+            composition_covered=False,
+            confidence=0.9,
+            rationale="cached",
+            model="claude-haiku-4-5",
+            ts=datetime.now(tz=timezone.utc).isoformat(),
+        ),
+    )
+    cpc = pl.DataFrame(
+        {
+            "rxn_id": ["USPTO:A:0"],
+            "patent_number": ["A"],
+            "patent_active": [True],
+            "cpc_ambiguous": [True],
+        }
+    )
+    patents = pl.DataFrame(
+        {
+            "patent_number": ["A"],
+            "abstract": ["x"],
+            "claims_text": ["1. claim"],
+            "cpc_codes": [["A61K"]],
+        }
+    )
+    reactions = pl.DataFrame({"rxn_id": ["USPTO:A:0"], "reaction_smiles": ["A>>B"]})
+    client = MagicMock()
+    out_path = tmp_path / "llm.parquet"
+    out_df = classify_ambiguous_patents(
+        cpc=cpc,
+        patents=patents,
+        reactions=reactions,
+        cache_path=cache_path,
+        out_path=out_path,
+        client=client,
+        model="claude-haiku-4-5",
+        max_retries=1,
+    )
+    assert client.messages.create.call_count == 0  # cache hit
+    assert out_df.height == 1
+    assert out_df["cache_hit"][0] is True
+    assert out_df["process_covered"][0] is True
+    for col, dtype in LLM_CLASSIFICATION_SCHEMA.items():
+        assert col in out_df.columns
+        assert out_df.schema[col] == dtype
+
+
+def test_classify_ambiguous_patents_calls_llm_on_cache_miss(tmp_path: Path):
+    cpc = pl.DataFrame(
+        {
+            "rxn_id": ["USPTO:B:0"],
+            "patent_number": ["B"],
+            "patent_active": [True],
+            "cpc_ambiguous": [True],
+        }
+    )
+    patents = pl.DataFrame(
+        {
+            "patent_number": ["B"],
+            "abstract": ["xyz"],
+            "claims_text": ["1. claim"],
+            "cpc_codes": [["A61K"]],
+        }
+    )
+    reactions = pl.DataFrame({"rxn_id": ["USPTO:B:0"], "reaction_smiles": ["A>>B"]})
+    client = MagicMock()
+    client.messages.create.return_value = _stub_anthropic_response(
+        process=False, composition=True, confidence=0.7, rationale="composition only",
+    )
+    cache_path = tmp_path / "cache.jsonl"
+    out_path = tmp_path / "llm.parquet"
+    out_df = classify_ambiguous_patents(
+        cpc=cpc, patents=patents, reactions=reactions,
+        cache_path=cache_path, out_path=out_path,
+        client=client, model="claude-haiku-4-5", max_retries=1,
+    )
+    assert client.messages.create.call_count == 1
+    assert out_df["cache_hit"][0] is False
+    assert out_df["composition_covered"][0] is True
+    # Cache file now has one entry
+    assert cache_path.exists()
+    assert "B" in cache_path.read_text()
+
+
+def test_classify_ambiguous_patents_skips_inactive(tmp_path: Path):
+    cpc = pl.DataFrame(
+        {
+            "rxn_id": ["USPTO:C:0"],
+            "patent_number": ["C"],
+            "patent_active": [False],
+            "cpc_ambiguous": [True],
+        }
+    )
+    patents = pl.DataFrame(
+        {"patent_number": ["C"], "abstract": [None], "claims_text": [None], "cpc_codes": [[]]}
+    )
+    reactions = pl.DataFrame({"rxn_id": ["USPTO:C:0"], "reaction_smiles": ["A>>B"]})
+    client = MagicMock()
+    out_path = tmp_path / "llm.parquet"
+    out_df = classify_ambiguous_patents(
+        cpc=cpc, patents=patents, reactions=reactions,
+        cache_path=tmp_path / "cache.jsonl", out_path=out_path,
+        client=client, model="claude-haiku-4-5", max_retries=1,
+    )
+    # Inactive patents are not LLM-classified
+    assert out_df.height == 0
+    assert client.messages.create.call_count == 0

--- a/tests/unit/test_patents_llm_classify.py
+++ b/tests/unit/test_patents_llm_classify.py
@@ -1,0 +1,59 @@
+from unittest.mock import MagicMock
+
+from aichemy.preprocessing.patents.llm_classify import (
+    LLMClassificationResult,
+    classify_patent_llm,
+)
+
+
+def _stub_anthropic_response(*, process: bool, composition: bool, confidence: float, rationale: str):
+    """Build a mock that mimics anthropic.Anthropic().messages.create() returning tool-use."""
+    block = MagicMock()
+    block.type = "tool_use"
+    block.name = "report_classification"
+    block.input = {
+        "process_covered": process,
+        "composition_covered": composition,
+        "confidence": confidence,
+        "rationale": rationale,
+    }
+    msg = MagicMock()
+    msg.stop_reason = "tool_use"
+    msg.content = [block]
+    return msg
+
+
+def test_classify_patent_llm_parses_tool_use():
+    client = MagicMock()
+    client.messages.create.return_value = _stub_anthropic_response(
+        process=True, composition=False, confidence=0.86, rationale="claim 1 method",
+    )
+    out = classify_patent_llm(
+        client=client,
+        patent_number="7456123",
+        title="A method",
+        abstract="Method for synthesis…",
+        claims_text="1. A process for…",
+        reaction_smiles_examples=["A>>B"],
+        model="claude-haiku-4-5",
+    )
+    assert isinstance(out, LLMClassificationResult)
+    assert out.process_covered is True
+    assert out.composition_covered is False
+    assert out.confidence == 0.86
+    assert out.rationale.startswith("claim")
+
+
+def test_classify_patent_llm_returns_none_on_unexpected_stop_reason():
+    client = MagicMock()
+    msg = MagicMock()
+    msg.stop_reason = "end_turn"
+    msg.content = []
+    client.messages.create.return_value = msg
+    out = classify_patent_llm(
+        client=client,
+        patent_number="X",
+        title="t", abstract="a", claims_text="c", reaction_smiles_examples=[],
+        model="claude-haiku-4-5",
+    )
+    assert out is None

--- a/tests/unit/test_patents_llm_classify.py
+++ b/tests/unit/test_patents_llm_classify.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -13,7 +13,9 @@ from aichemy.preprocessing.patents.llm_classify import (
 )
 
 
-def _stub_anthropic_response(*, process: bool, composition: bool, confidence: float, rationale: str):
+def _stub_anthropic_response(
+    *, process: bool, composition: bool, confidence: float, rationale: str
+):
     """Build a mock that mimics anthropic.Anthropic().messages.create() returning tool-use."""
     block = MagicMock()
     block.type = "tool_use"
@@ -77,7 +79,7 @@ def test_classify_ambiguous_patents_uses_cache_when_present(tmp_path: Path):
             confidence=0.9,
             rationale="cached",
             model="claude-haiku-4-5",
-            ts=datetime.now(tz=timezone.utc).isoformat(),
+            ts=datetime.now(tz=UTC).isoformat(),
         ),
     )
     cpc = pl.DataFrame(

--- a/tests/unit/test_patents_llm_classify.py
+++ b/tests/unit/test_patents_llm_classify.py
@@ -35,7 +35,10 @@ def _stub_anthropic_response(
 def test_classify_patent_llm_parses_tool_use():
     client = MagicMock()
     client.messages.create.return_value = _stub_anthropic_response(
-        process=True, composition=False, confidence=0.86, rationale="claim 1 method",
+        process=True,
+        composition=False,
+        confidence=0.86,
+        rationale="claim 1 method",
     )
     out = classify_patent_llm(
         client=client,
@@ -62,7 +65,10 @@ def test_classify_patent_llm_returns_none_on_unexpected_stop_reason():
     out = classify_patent_llm(
         client=client,
         patent_number="X",
-        title="t", abstract="a", claims_text="c", reaction_smiles_examples=[],
+        title="t",
+        abstract="a",
+        claims_text="c",
+        reaction_smiles_examples=[],
         model="claude-haiku-4-5",
     )
     assert out is None
@@ -140,14 +146,22 @@ def test_classify_ambiguous_patents_calls_llm_on_cache_miss(tmp_path: Path):
     reactions = pl.DataFrame({"rxn_id": ["USPTO:B:0"], "reaction_smiles": ["A>>B"]})
     client = MagicMock()
     client.messages.create.return_value = _stub_anthropic_response(
-        process=False, composition=True, confidence=0.7, rationale="composition only",
+        process=False,
+        composition=True,
+        confidence=0.7,
+        rationale="composition only",
     )
     cache_path = tmp_path / "cache.jsonl"
     out_path = tmp_path / "llm.parquet"
     out_df = classify_ambiguous_patents(
-        cpc=cpc, patents=patents, reactions=reactions,
-        cache_path=cache_path, out_path=out_path,
-        client=client, model="claude-haiku-4-5", max_retries=1,
+        cpc=cpc,
+        patents=patents,
+        reactions=reactions,
+        cache_path=cache_path,
+        out_path=out_path,
+        client=client,
+        model="claude-haiku-4-5",
+        max_retries=1,
     )
     assert client.messages.create.call_count == 1
     assert out_df["cache_hit"][0] is False
@@ -173,9 +187,14 @@ def test_classify_ambiguous_patents_skips_inactive(tmp_path: Path):
     client = MagicMock()
     out_path = tmp_path / "llm.parquet"
     out_df = classify_ambiguous_patents(
-        cpc=cpc, patents=patents, reactions=reactions,
-        cache_path=tmp_path / "cache.jsonl", out_path=out_path,
-        client=client, model="claude-haiku-4-5", max_retries=1,
+        cpc=cpc,
+        patents=patents,
+        reactions=reactions,
+        cache_path=tmp_path / "cache.jsonl",
+        out_path=out_path,
+        client=client,
+        model="claude-haiku-4-5",
+        max_retries=1,
     )
     # Inactive patents are not LLM-classified
     assert out_df.height == 0

--- a/tests/unit/test_solve_sweep.py
+++ b/tests/unit/test_solve_sweep.py
@@ -1,0 +1,83 @@
+"""Tests for the `solve sweep` CLI helper (Task 18)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import polars as pl
+
+from aichemy.solver.cli import _run_sweep
+from aichemy.solver.config import SolverConfig
+
+
+def _fixture():
+    reactions = pl.DataFrame(
+        {
+            "rxn_id": ["RX1"],
+            "yield_rate": [1.0],
+            "reactants": [[{"mol_id": "A", "coefficient": 1.0}]],
+            "products": [[{"mol_id": "C", "coefficient": 1.0}]],
+            "rdkit_balanced": [True],
+            "balanced": [True],
+            "patent_active": [True],
+            "process_covered": [True],
+            "composition_covered": [True],
+        }
+    )
+    molecules = pl.DataFrame({"mol_id": ["A", "C"], "price_per_gram": [1.0, 10.0]})
+    return reactions, molecules
+
+
+def test_sweep_writes_summary_with_one_row_per_grid_point(tmp_path: Path):
+    reactions, molecules = _fixture()
+    summary = _run_sweep(
+        reactions,
+        molecules,
+        r_process_grid=[0.0, 0.05],
+        r_comp_grid=[0.0, 0.05],
+        out_dir=tmp_path,
+        base_config=SolverConfig(),
+    )
+    assert summary.height == 4
+    assert set(summary.columns) >= {
+        "r_process",
+        "r_comp",
+        "objective_value",
+        "n_active_reactions",
+        "n_sold_products",
+        "set_hash",
+        "infeasible",
+    }
+    assert (tmp_path / "summary.parquet").exists()
+
+
+def test_sweep_set_hash_changes_when_active_set_changes(tmp_path: Path):
+    """Very high royalty turns the patent-covered route off → different set_hash."""
+    reactions, molecules = _fixture()
+    summary = _run_sweep(
+        reactions,
+        molecules,
+        r_process_grid=[0.0, 0.99],
+        r_comp_grid=[0.0],
+        out_dir=tmp_path,
+        base_config=SolverConfig(),
+    )
+    hashes = summary["set_hash"].to_list()
+    assert hashes[0] != hashes[1]
+
+
+def test_sweep_writes_per_cell_solution_files(tmp_path: Path):
+    reactions, molecules = _fixture()
+    _run_sweep(
+        reactions,
+        molecules,
+        r_process_grid=[0.0],
+        r_comp_grid=[0.0],
+        out_dir=tmp_path,
+        base_config=SolverConfig(),
+    )
+    cells = list((tmp_path / "runs").glob("r_process_*_r_comp_*"))
+    assert len(cells) == 1
+    sol = json.loads((cells[0] / "solution.json").read_text())
+    assert "objective_value" in sol

--- a/tests/unit/test_solver_config_royalty.py
+++ b/tests/unit/test_solver_config_royalty.py
@@ -1,0 +1,13 @@
+from aichemy.solver.config import SolverConfig
+
+
+def test_solver_config_has_royalty_defaults():
+    cfg = SolverConfig()
+    assert cfg.r_process == 0.0
+    assert cfg.r_comp == 0.0
+
+
+def test_solver_config_accepts_custom_royalties():
+    cfg = SolverConfig(r_process=0.05, r_comp=0.03)
+    assert cfg.r_process == 0.05
+    assert cfg.r_comp == 0.03

--- a/tests/unit/test_solver_royalty.py
+++ b/tests/unit/test_solver_royalty.py
@@ -1,0 +1,80 @@
+"""Royalty terms in the MILP objective (Task 17).
+
+Three invariants:
+1. Zero-royalty equivalence — same objective as legacy when r_process=r_comp=0.
+2. Process royalty reduces objective by exactly r_process · price_sell · η · f.
+3. Composition royalty reduces objective by exactly r_comp · price_sell · q_sell.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+from aichemy.solver.config import SolverConfig
+from aichemy.solver.model import build_and_solve
+
+
+def _two_reaction_fixture(*, process_covered: bool, composition_covered: bool):
+    """Single reaction A + B → C; price A=1, B=1, C=10; yield 1.0; balanced=True."""
+    reactions = pl.DataFrame(
+        {
+            "rxn_id": ["RX1"],
+            "yield_rate": [1.0],
+            "reactants": [
+                [
+                    {"mol_id": "A", "coefficient": 1.0},
+                    {"mol_id": "B", "coefficient": 1.0},
+                ]
+            ],
+            "products": [[{"mol_id": "C", "coefficient": 1.0}]],
+            "rdkit_balanced": [True],
+            "balanced": [True],
+            "patent_active": [process_covered or composition_covered],
+            "process_covered": [process_covered],
+            "composition_covered": [composition_covered],
+        }
+    )
+    molecules = pl.DataFrame(
+        {
+            "mol_id": ["A", "B", "C"],
+            "price_per_gram": [1.0, 1.0, 10.0],
+        }
+    )
+    return reactions, molecules
+
+
+def test_zero_royalty_matches_baseline_objective():
+    """At r_process=r_comp=0, royalty terms are no-ops; objective matches legacy."""
+    reactions, molecules = _two_reaction_fixture(process_covered=True, composition_covered=True)
+    sol_zero = build_and_solve(reactions, molecules, SolverConfig(r_process=0.0, r_comp=0.0))
+    # Drop license columns to simulate the pre-licensing solver path.
+    reactions_legacy = reactions.drop(["patent_active", "process_covered", "composition_covered"])
+    sol_legacy = build_and_solve(reactions_legacy, molecules, SolverConfig())
+    assert abs(sol_zero.objective_value - sol_legacy.objective_value) < 1e-3
+
+
+def test_process_royalty_reduces_objective_by_expected_amount():
+    """At r_process=0.5, process-covered reaction pays 0.5 · price_sell[product] · η · f."""
+    reactions, molecules = _two_reaction_fixture(process_covered=True, composition_covered=False)
+    sol_no = build_and_solve(reactions, molecules, SolverConfig(r_process=0.0, r_comp=0.0))
+    sol_p = build_and_solve(reactions, molecules, SolverConfig(r_process=0.5, r_comp=0.0))
+    flow = sol_no.activated_reactions[0]["flow"]
+    expected_delta = 0.5 * 10.0 * 1.0 * flow  # rate · price[C] · yield · f
+    assert abs((sol_no.objective_value - sol_p.objective_value) - expected_delta) < 1e-2
+
+
+def test_composition_royalty_reduces_objective_by_expected_amount():
+    """At r_comp=0.5, composition-covered product pays 0.5 · price_sell · q_sell.
+
+    Uses a tight max_flow=1 / budget=2 config so the only economic activity is:
+    buy 1 A + 1 B → produce 1 C → sell 1 C. Eliminates the LP's degenerate
+    buy-resell of C (which would inflate q_sell[C] and make the delta
+    sensitive to the optimizer's tie-breaking).
+    """
+    reactions, molecules = _two_reaction_fixture(process_covered=False, composition_covered=True)
+    base = {"max_flow": 1.0, "budget": 2.0}
+    sol_no = build_and_solve(reactions, molecules, SolverConfig(**base, r_process=0.0, r_comp=0.0))
+    sol_c = build_and_solve(reactions, molecules, SolverConfig(**base, r_process=0.0, r_comp=0.5))
+    sold_qty = next(s for s in sol_no.sold_molecules if s["mol_id"] == "C")["quantity"]
+    expected_delta = 0.5 * 10.0 * sold_qty
+    assert abs((sol_no.objective_value - sol_c.objective_value) - expected_delta) < 1e-2

--- a/uv.lock
+++ b/uv.lock
@@ -64,6 +64,7 @@ dev = [
     { name = "pytest-httpx" },
     { name = "responses" },
     { name = "ruff" },
+    { name = "types-requests" },
 ]
 
 [package.metadata]
@@ -102,6 +103,7 @@ dev = [
     { name = "pytest-httpx", specifier = ">=0.36" },
     { name = "responses", specifier = ">=0.25" },
     { name = "ruff", specifier = ">=0.4" },
+    { name = "types-requests", specifier = ">=2.31" },
 ]
 
 [[package]]
@@ -5756,6 +5758,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.33.0.20260408"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/6a/749dc53a54a3f35842c1f8197b3ca6b54af6d7458a1bfc75f6629b6da666/types_requests-2.33.0.20260408.tar.gz", hash = "sha256:95b9a86376807a216b2fb412b47617b202091c3ea7c078f47cc358d5528ccb7b", size = 23882, upload-time = "2026-04-08T04:34:49.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/b8/78fd6c037de4788c040fdd323b3369804400351b7827473920f6c1d03c10/types_requests-2.33.0.20260408-py3-none-any.whl", hash = "sha256:81f31d5ea4acb39f03be7bc8bed569ba6d5a9c5d97e89f45ac43d819b68ca50f", size = 20739, upload-time = "2026-04-08T04:34:48.325Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Rollup PR landing the complete patent-licensing feature from `licensing-integration` into `main`. Includes Plans A through G:

- **A**: Foundation (deps, config, schema, paths)
- **B**: PatentsView fetch + CPC classifier
- **C**: LLM classifier with persistent JSONL cache
- **D**: `augment_licenses` merge step
- **E**: MILP royalty terms (`r_process`, `r_comp`) + `solve sweep` CLI
- **F**: DVC wiring + integration test
- **G**: USPTO ODP migration (PatentsView v1 was deprecated mid-2026; migrated to api.uspto.gov + auth-error propagation)

## Conflict resolution

`main` had moved on independently (PR #35 added a `select_reactions` stage). The merge had real conflicts in `dvc.yaml` and `src/aichemy/cli.py`. Resolution:

| Conflict | Resolution |
|---|---|
| Two new typer subapps (`patents_app`, `select_app`) | Take both — additive |
| Two new CLI command blocks (licensing commands vs `select_reactions_cmd`) | Take both — additive |
| `export` stage's reactions input (`reactions_licensed.parquet` vs `selected/reactions.parquet`) | Take licensing's `reactions_licensed.parquet` — primary user goal is license analysis |
| `dvc.yaml` new stage block (4 licensing stages vs 1 select stage) | Take both stage definitions; both feed off `reactions_full.parquet` in parallel |

**Known follow-up:** the `select_reactions` stage runs in the merged DAG but its output is not currently consumed by `export` (the licensing path takes priority). A future architectural decision is whether to chain select → licensing or run them in parallel. Not blocking for this rollup.

## DVC stage impact (after merge)

Stages flagged stale only because of code-dep file hash changes (no behavior change):

- `fetch_raw` (cli.py changed) — bless via `dvc commit fetch_raw`
- `balance_uspto` (configs/default.yaml changed; SYN-RBL behavior unaffected) — bless via `dvc commit balance_uspto` to avoid the 4-hour rerun
- `export` — actually needs to rerun because input dep is now `reactions_licensed.parquet`

New stages requiring real execution:
- `fetch_patent_metadata`, `classify_licenses_cpc`, `classify_licenses_llm`, `augment_licenses`, `select_reactions`

## Test plan

- [x] `uv run pytest tests/ --ignore=tests/unit/test_balance_syn_rbl.py` — **262 passed**, 1 skipped (synrbl env-only)
- [x] `uv run ruff check .` and `ruff format --check .` — clean
- [x] `uv run python -c "from aichemy.cli import app"` — imports successfully
- [x] `uv run yaml.safe_load(open("dvc.yaml"))` — parses
- [x] Live end-to-end validation on a curated 10-reaction mix (5 expired + 5 modern pharma patents) on the merged code: 4/10 reactions correctly flagged composition-covered via real USPTO ODP fetch + real Anthropic Haiku 4.5 LLM judgments

## Notes

- The merge commit (`5113b5d`) preserves both branches' history
- `licensing-integration` branch can be archived after this lands
- After merge, run `dvc commit fetch_raw balance_uspto` then `dvc repro export` to refresh the pipeline without re-running expensive upstream stages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

## ⚠️ Post-merge action required (avoid 4hr SYN-RBL rerun)

The merge changes `configs/default.yaml` (adds the `selection` block from PR #35) and `src/aichemy/cli.py`. DVC will flag every existing stage as stale because they all depend on these files — but the actual changes don't affect any existing stage's behavior.

**Run this BEFORE `dvc repro` to bless existing outputs:**

```bash
git pull
dvc commit fetch_raw ingest_metanetx ingest_uspto normalize \
           dedup_molecules dedup_reactions \
           balance_uspto drop_unbalanced balance_validate \
           augment_yields augment_prices augment_thermo augment_directionality
```

Then:

```bash
dvc repro export   # fires only new stages: fetch_patent_metadata, classify_licenses_cpc, classify_licenses_llm, augment_licenses, select_reactions, export
```

This avoids re-running the expensive stages (balance_uspto ~4hr, augment_thermo eQuilibrator API calls).